### PR TITLE
Use selected pin for AVR direct port toggle

### DIFF
--- a/UniversalArduinoBenchmark.ino
+++ b/UniversalArduinoBenchmark.ino
@@ -921,11 +921,13 @@ void benchmarkDigitalIO() {
 
 // Direct port manipulation (AVR only)
 #ifdef __AVR__
+  volatile uint8_t *out = portOutputRegister(digitalPinToPort(testPin));
+  uint8_t mask = digitalPinToBitMask(testPin);
   iterations = 0;
   startBenchmark();
   for (int i = 0; i < 1000; i++) {
-    PORTB |= (1 << PB5);   // Set
-    PORTB &= ~(1 << PB5);  // Clear
+    *out |= mask;   // Set
+    *out &= ~mask;  // Clear
     iterations += 2;
   }
   unsigned long portTime = endBenchmark();


### PR DESCRIPTION
### Motivation
- The direct-port digital I/O benchmark used a hardcoded `PORTB`/`PB5` toggle which could target the wrong pin on AVR boards when `testPin` differed from PB5.
- Update the benchmark so the direct-port test toggles the same pin as `digitalWrite(testPin)` across AVR variants.

### Description
- In `UniversalArduinoBenchmark.ino` compute the AVR output register pointer with `portOutputRegister(digitalPinToPort(testPin))` and the bit mask with `digitalPinToBitMask(testPin)`.
- Replace the fixed `PORTB |= (1 << PB5)` / `PORTB &= ~(1 << PB5)` sequence with `*out |= mask` / `*out &= ~mask` to write through the register pointer.
- The change is applied inside the existing `#ifdef __AVR__` block in the `benchmarkDigitalIO()` function and committed to the repository.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979c1dc4f3483319192c9a3c6633c23)