### PR TITLE
Add ESP32 PWM setup timing in analog I/O benchmark

### DIFF
--- a/UniversalArduinoBenchmark.ino
+++ b/UniversalArduinoBenchmark.ino
@@ -1038,6 +1038,38 @@ void benchmarkAnalogIO() {
 
   // analogWrite/PWM benchmark
   if (analogOutPin >= 0) {
+#if defined(ESP32)
+    const int pwmChannel = 0;
+    const int pwmFreq = 5000;
+    const int pwmResolution = 8;
+
+    startBenchmark();
+    ledcSetup(pwmChannel, pwmFreq, pwmResolution);
+    ledcAttachPin(analogOutPin, pwmChannel);
+    unsigned long setupTime = endBenchmark();
+
+    volatile uint32_t iterations = 0;
+    startBenchmark();
+    for (int i = 0; i < 100; i++) {
+      ledcWrite(pwmChannel, i % 256);
+      iterations++;
+    }
+    unsigned long updateTime = endBenchmark();
+
+    Serial.print(F("PWM setup: "));
+    Serial.print(setupTime);
+    Serial.print(F(" μs ("));
+    Serial.print(1000.0 / setupTime);
+    Serial.println(F(" ops/ms)"));
+
+    Serial.print(F("PWM duty update ("));
+    Serial.print(iterations);
+    Serial.print(F(" ops): "));
+    Serial.print(updateTime);
+    Serial.print(F(" μs ("));
+    Serial.print(iterations * 1000.0 / updateTime);
+    Serial.println(F(" ops/ms)"));
+#else
     pinMode(analogOutPin, OUTPUT);
     volatile uint32_t iterations = 0;
     startBenchmark();
@@ -1054,6 +1086,7 @@ void benchmarkAnalogIO() {
     Serial.print(F(" μs ("));
     Serial.print(iterations * 1000.0 / writeTime);
     Serial.println(F(" ops/ms)"));
+#endif
   }
 }
 


### PR DESCRIPTION
### Motivation
- Make the analog I/O benchmark reflect steady-state PWM costs on ESP32 by separating the one-time PWM channel configuration cost from recurring duty updates.

### Description
- Update `benchmarkAnalogIO()` in `UniversalArduinoBenchmark.ino` to add an `#if defined(ESP32)` branch that times `ledcSetup()`/`ledcAttachPin()` as a `PWM setup` measurement and then times `ledcWrite()` calls as `PWM duty update` measurements.
- Use `pwmChannel = 0`, `pwmFreq = 5000`, and `pwmResolution = 8`, and perform 100 duty updates to match the existing loop count logic.
- Preserve original behavior for AVR and other architectures by keeping the existing `pinMode()` + `analogWrite()` path under the `#else` branch.
- Print both `PWM setup` and `PWM duty update` results to `Serial` for clear reporting.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979c27edd7083319e32ea4811f166b7)