### PR TITLE
Skip stack depth test on AVR and clarify stack-usage output

### DIFF
--- a/UniversalArduinoBenchmark.ino
+++ b/UniversalArduinoBenchmark.ino
@@ -1572,10 +1572,17 @@ int testRecursion(int depth) {
 void benchmarkStackDepth() {
   printHeader("MEMORY: Stack Depth Test");
 
+#if defined(__AVR__)
+  Serial.println(F("Stack depth test skipped on low-SRAM AVR targets."));
+  Serial.println(F("Reason: recursion can exhaust limited SRAM quickly."));
+  return;
+#endif
+
   // Test safe recursion depth
   recursionCounter = 0;
   int testDepth = 100;
   int result = testRecursion(testDepth);
+  (void)result;
 
   Serial.print(F("Recursion test ("));
   Serial.print(testDepth);
@@ -1585,12 +1592,7 @@ void benchmarkStackDepth() {
   } else {
     Serial.println(F("FAIL"));
   }
-
-  Serial.print(F("Each call uses ~32 bytes"));
-  Serial.println();
-  Serial.print(F("Test consumed ~"));
-  Serial.print(testDepth * 32);
-  Serial.println(F(" bytes of stack"));
+  Serial.println(F("Per-call stack usage not measured on this platform."));
 }
 
 // ==================== MULTI-CORE BENCHMARKS ====================


### PR DESCRIPTION
### Motivation
- Recursion-based stack probing can exhaust very limited SRAM on AVR boards, so the test should be skipped on low-RAM targets to avoid crashes.
- The sketch previously printed a hardcoded “~32 bytes per call” figure without actually measuring per-call stack usage, which is misleading.

### Description
- In `UniversalArduinoBenchmark.ino` the `benchmarkStackDepth()` function now early-returns on AVR targets with a clear message when `__AVR__` is defined.
- Removed the hardcoded per-call stack usage/statements and replaced them with a message stating that per-call stack usage is not measured on this platform.
- Added `(void)result;` to silence the unused-variable warning after running the recursion on supported platforms.
- Changes made in `UniversalArduinoBenchmark.ino` to avoid performing risky recursion on low-SRAM targets and to clarify output text.

### Testing
- No automated tests were run for this change.
- The file was modified and committed (`UniversalArduinoBenchmark.ino`) without additional test execution.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979c27e20208331898d0715ce51c767)