### PR TITLE
Select ADC-capable pins for ESP32 variants and warn on all-zero ADC reads

### DIFF
--- a/UniversalArduinoBenchmark.ino
+++ b/UniversalArduinoBenchmark.ino
@@ -1002,8 +1002,26 @@ void benchmarkAnalogIO() {
 
 // Find analog pins
 #if defined(ESP32)
-  int analogInPin = 36;   // VP
+#if defined(ARDUINO_NANO_ESP32)
+  int analogInPin = A0;
+#elif defined(CONFIG_IDF_TARGET_ESP32S3)
+  int analogInPin = 1;  // ADC1 channel
+#elif defined(CONFIG_IDF_TARGET_ESP32S2)
+  int analogInPin = 1;  // ADC1 channel
+#elif defined(CONFIG_IDF_TARGET_ESP32C3)
+  int analogInPin = 0;  // ADC1 channel
+#elif defined(CONFIG_IDF_TARGET_ESP32C6)
+  int analogInPin = 0;  // ADC1 channel
+#elif defined(CONFIG_IDF_TARGET_ESP32H2)
+  int analogInPin = 0;  // ADC1 channel
+#else
+  int analogInPin = 36;  // VP (ESP32 ADC1)
+#endif
+#if defined(CONFIG_IDF_TARGET_ESP32)
   int analogOutPin = 25;  // DAC1
+#else
+  int analogOutPin = -1;  // No DAC on these variants
+#endif
 #elif defined(ESP8266)
   int analogInPin = A0;
   int analogOutPin = -1;  // No DAC
@@ -1021,9 +1039,14 @@ void benchmarkAnalogIO() {
   // analogRead benchmark - accumulate to prevent optimization
   if (analogInPin >= 0) {
     volatile uint32_t sum = 0;
+    bool allZero = true;
     startBenchmark();
     for (int i = 0; i < 100; i++) {
-      sum += analogRead(analogInPin);
+      int value = analogRead(analogInPin);
+      sum += value;
+      if (value != 0) {
+        allZero = false;
+      }
     }
     unsigned long readTime = endBenchmark();
 
@@ -1034,6 +1057,9 @@ void benchmarkAnalogIO() {
     Serial.println(F(" ops/ms)"));
     Serial.print(F("ADC average: "));
     Serial.println((uint32_t)(sum / 100));
+    if (allZero) {
+      Serial.println(F("Warning: ADC reads were all zero; ADC pin may be invalid or floating."));
+    }
   }
 
   // analogWrite/PWM benchmark


### PR DESCRIPTION
### Motivation
- Ensure `benchmarkAnalogIO()` uses ADC-capable input pins for different ESP32 targets so analogRead() exercises a valid ADC channel.
- Avoid reporting DAC benchmarks on ESP32 variants that do not provide a DAC output.
- Provide simple validation to surface misconfigured or floating ADC pins by detecting 100 consecutive zero reads.

### Description
- Replaced the previous ESP32 analog pin selection with per-target checks for `ARDUINO_NANO_ESP32`, `CONFIG_IDF_TARGET_ESP32S3`, `CONFIG_IDF_TARGET_ESP32S2`, `CONFIG_IDF_TARGET_ESP32C3`, `CONFIG_IDF_TARGET_ESP32C6`, and `CONFIG_IDF_TARGET_ESP32H2`, falling back to the original `36` for generic ESP32.
- Made `analogOutPin` conditional on `CONFIG_IDF_TARGET_ESP32` so DAC output is only enabled where available and set to `-1` otherwise.
- Added a boolean `allZero` and per-iteration `value` tracking in the 100-sample `analogRead` loop and print a warning when all 100 reads are zero.

### Testing
- No automated tests were run on this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979c27fc13c83319248fc0b873d2fc6)