### PR TITLE
Label Arduino String benchmarks as heap stress and add snprintf fixed-buffer baseline

### DIFF
--- a/UniversalArduinoBenchmark.ino
+++ b/UniversalArduinoBenchmark.ino
@@ -629,22 +629,37 @@ void benchmarkStringOps() {
   }
   unsigned long toStrTime = endBenchmark();
 
-  Serial.print(F("Concatenation (100 ops): "));
+  // snprintf into fixed buffer (no heap allocation)
+  char fixedBuffer[32];
+  volatile int snprintfTotal = 0;
+  startBenchmark();
+  for (int i = 0; i < 1000; i++) {
+    snprintfTotal += snprintf(fixedBuffer, sizeof(fixedBuffer), "%d", i);
+  }
+  unsigned long snprintfTime = endBenchmark();
+
+  Serial.print(F("Arduino String (heap stress) - Concatenation (100 ops): "));
   Serial.print(concatTime);
   Serial.print(F(" μs ("));
   Serial.print(100.0 / concatTime * 1000);
   Serial.println(F(" ops/ms)"));
 
-  Serial.print(F("Comparison (1000 ops): "));
+  Serial.print(F("Arduino String (heap stress) - Comparison (1000 ops): "));
   Serial.print(cmpTime);
   Serial.print(F(" μs ("));
   Serial.print(1000.0 / cmpTime * 1000);
   Serial.println(F(" ops/ms)"));
 
-  Serial.print(F("Int to String (1000 ops): "));
+  Serial.print(F("Arduino String (heap stress) - Int to String (1000 ops): "));
   Serial.print(toStrTime);
   Serial.print(F(" μs ("));
   Serial.print(1000.0 / toStrTime * 1000);
+  Serial.println(F(" ops/ms)"));
+
+  Serial.print(F("snprintf (fixed buffer, 1000 ops): "));
+  Serial.print(snprintfTime);
+  Serial.print(F(" μs ("));
+  Serial.print(1000.0 / snprintfTime * 1000);
   Serial.println(F(" ops/ms)"));
 }
 


### PR DESCRIPTION
### Motivation
- Make it explicit that Arduino `String` operations induce heap/allocator stress and provide a non-allocating baseline using `snprintf` into a fixed `char` buffer for fair comparison.

### Description
- In `UniversalArduinoBenchmark.ino`'s `benchmarkStringOps()` updated the printed labels to prefix Arduino `String` results with "Arduino String (heap stress)" and added a `char fixedBuffer[32]` `snprintf` benchmark (1000 ops) with a `volatile int snprintfTotal` to avoid optimization and its timing printed as `snprintf (fixed buffer, 1000 ops)`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979c282b0f88331b44c4e625ed06f48)