### PR TITLE
Match integer multiplication/division loop bounds to reported ops count

### DIFF
--- a/UniversalArduinoBenchmark.ino
+++ b/UniversalArduinoBenchmark.ino
@@ -481,7 +481,7 @@ void benchmarkIntegerOps() {
   // Multiplication - use LCG-style updates to prevent optimization
   acc = 1;
   startBenchmark();
-  for (uint32_t i = 1; i < BENCHMARK_ITERATIONS / 100; i++) {
+  for (uint32_t i = 1; i <= BENCHMARK_ITERATIONS / 100; i++) {
     acc = (acc * (i | 1)) & 0xFFFFFFFF;  // Ensure odd multiplier, prevent overflow
   }
   unsigned long mulTime = endBenchmark();
@@ -491,7 +491,7 @@ void benchmarkIntegerOps() {
   // Division - vary both dividend and divisor
   acc = 0xFFFFFFFFULL;
   startBenchmark();
-  for (uint32_t i = 1; i < BENCHMARK_ITERATIONS / 100; i++) {
+  for (uint32_t i = 1; i <= BENCHMARK_ITERATIONS / 100; i++) {
     uint32_t divisor = (i % 127) + 2;  // 2-128, avoid div-by-1
     acc = (acc / divisor) + i;         // Accumulate to prevent optimization
   }


### PR DESCRIPTION
### Motivation
- Ensure the printed operations counts for integer multiplication and division reflect the actual number of loop iterations executed.

### Description
- Change the multiplication and division loops in `benchmarkIntegerOps()` from `for (uint32_t i = 1; i < BENCHMARK_ITERATIONS / 100; i++)` to `for (uint32_t i = 1; i <= BENCHMARK_ITERATIONS / 100; i++)` in `UniversalArduinoBenchmark.ino` so the reported `BENCHMARK_ITERATIONS / 100` matches the real iteration count.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979c284451c83318cc7e7e987995f03)