### PR TITLE
Use float math and range wrapping in CPU stress loop

### DIFF
--- a/UniversalArduinoBenchmark.ino
+++ b/UniversalArduinoBenchmark.ino
@@ -404,12 +404,14 @@ void benchmarkCPUStress() {
   unsigned long stressStart = millis();
   unsigned long iterations = 0;
   volatile float result = 1.0f;
+  const float twoPi = 6.2831853f;
 
   while (millis() - stressStart < 10000) {
     // Mix of integer and float operations
     for (int i = 0; i < 100; i++) {
-      result = result * 1.0001f + sqrt((float)i);
-      result = sin(result) + cos(result);
+      result = result * 1.0001f + sqrtf((float)i);
+      result = fmodf(result, twoPi);
+      result = sinf(result) + cosf(result);
       iterations++;
     }
 


### PR DESCRIPTION
### Motivation
- Prevent range-reduction blowups and keep the CPU stress loop representative of steady-state float math by using float-specific trig/sqrt and constraining the argument range in `benchmarkCPUStress()` in `UniversalArduinoBenchmark.ino`.

### Description
- In `UniversalArduinoBenchmark.ino` inside `benchmarkCPUStress()` replace `sqrt`/`sin`/`cos` with the float variants `sqrtf`/`sinf`/`cosf`, add `const float twoPi = 6.2831853f`, and apply `fmodf(result, twoPi)` before the trig calls to keep `result` in a small range.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979c289dabc833184233ebde1400bab)