### PR TITLE
Replace ESP32 per-iteration delay with fixed arithmetic work

### DIFF
--- a/UniversalArduinoBenchmark.ino
+++ b/UniversalArduinoBenchmark.ino
@@ -1605,20 +1605,24 @@ volatile unsigned long core1Count = 0;
 volatile bool testRunning = false;
 
 void core0Task(void* parameter) {
+  volatile uint32_t accumulator = 0;
   while (true) {
     if (testRunning) {
       core0Count++;
+      accumulator += 3;
+      accumulator ^= (accumulator << 1);
     }
-    delayMicroseconds(1);
   }
 }
 
 void core1Task(void* parameter) {
+  volatile uint32_t accumulator = 0;
   while (true) {
     if (testRunning) {
       core1Count++;
+      accumulator += 3;
+      accumulator ^= (accumulator << 1);
     }
-    delayMicroseconds(1);
   }
 }
 #endif


### PR DESCRIPTION
### Motivation
- Replace the per-iteration `delayMicroseconds(1)` in the ESP32 core tasks so the multi-core benchmark reflects fixed CPU throughput (or, alternatively, to allow relabeling as a scheduler fairness test if the delay is retained). 

### Description
- In `UniversalArduinoBenchmark.ino` remove `delayMicroseconds(1)` from `core0Task` and `core1Task` and add a local `volatile uint32_t accumulator` updated each iteration with `accumulator += 3; accumulator ^= (accumulator << 1);` while keeping `core0Count`/`core1Count` behavior unchanged. 

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979c285d5a4833195a2a20d6d31da42)