### PR TITLE
Clarify Serial.flush timing label

### DIFF
--- a/UniversalArduinoBenchmark.ino
+++ b/UniversalArduinoBenchmark.ino
@@ -1093,9 +1093,9 @@ void benchmarkSerial() {
   Serial.print(expectedBytes * 1000.0 / enqueueTime);
   Serial.println(F(" bytes/ms CPU)"));
 
-  Serial.print(F("flush() Time: "));
+  Serial.print(F("flush() time (implementation-dependent): "));
   Serial.print(flushTime);
-  Serial.print(F(" μs (buffer→FIFO)"));
+  Serial.print(F(" μs"));
   Serial.println();
 
   Serial.print(F("Theoretical Wire Time: "));


### PR DESCRIPTION
### Motivation
- Avoid asserting a specific implementation behavior in `benchmarkSerial()` output while preserving the measured `flush()` time because semantics of `flush()` vary across cores.

### Description
- Change the printed label in `benchmarkSerial()` to `flush() time (implementation-dependent): ` and remove the ` (buffer→FIFO)` claim while keeping the `flushTime` measurement.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979c284f2f08331834de2da8526d4a9)