### PR TITLE
Add minimum-duration benchmark helper `runForAtLeastUs`

### DIFF
--- a/UniversalArduinoBenchmark.ino
+++ b/UniversalArduinoBenchmark.ino
@@ -355,6 +355,27 @@ unsigned long endBenchmark() {
   return micros() - benchmarkStart;
 }
 
+struct MinDurationResult {
+  uint32_t ops;
+  unsigned long elapsedUs;
+};
+
+template <typename Func>
+MinDurationResult runForAtLeastUs(unsigned long minUs, Func fn) {
+  MinDurationResult result = {};
+  unsigned long start = micros();
+  unsigned long elapsed = 0;
+  do {
+    result.ops += fn();
+#if defined(ESP32) || defined(ESP8266) || defined(ARDUINO_ARCH_RP2040)
+    yield();
+#endif
+    elapsed = micros() - start;
+  } while (elapsed < minUs);
+  result.elapsedUs = elapsed;
+  return result;
+}
+
 struct TimedLoopResult {
   unsigned long elapsedMicros;
   uint32_t iterations;


### PR DESCRIPTION
### Motivation
- Provide a small reusable helper to run microbenchmarks for at least a specified number of microseconds while safely yielding on cores that need it, so callers can accumulate operations over a minimum time window.

### Description
- Add `struct MinDurationResult` with `ops` and `elapsedUs` fields to hold results.
- Add template helper `runForAtLeastUs(unsigned long minUs, Func fn)` that loops until `micros()` exceeds `minUs`, accumulates the `uint32_t` ops returned by `fn()`, and returns a `MinDurationResult`.
- Call `yield()` inside the loop on `ESP32`, `ESP8266`, and `ARDUINO_ARCH_RP2040` to keep USB/RTOS/USB services responsive during long tight loops.
- Change is implemented in `UniversalArduinoBenchmark.ino` adjacent to the existing `startBenchmark()`/`endBenchmark()` helpers.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979c666cbbc833182d6ebcf9c0243f9)