### PR TITLE
Calibrate benchmark minimum duration based on micros() resolution

### DIFF
--- a/UniversalArduinoBenchmark.ino
+++ b/UniversalArduinoBenchmark.ino
@@ -331,6 +331,7 @@
 
 // ==================== GLOBAL VARIABLES ====================
 uint8_t testBuffer[256];
+unsigned long gMinBenchUs = 20000;
 
 // ==================== HELPER FUNCTIONS ====================
 
@@ -397,6 +398,30 @@ TimedLoopResult runTimedLoop(uint32_t minDurationMs, uint32_t opsPerIteration, F
   result.elapsedMicros = elapsed;
   result.opsPerMs = (result.totalOps * 1000.0f) / result.elapsedMicros;
   return result;
+}
+
+void calibrateBenchmarkTime() {
+  unsigned long start = micros();
+  unsigned long next = start;
+  uint32_t spins = 0;
+  while (next == start && spins < 100000) {
+    next = micros();
+    spins++;
+  }
+  unsigned long microsResolution = next - start;
+
+  unsigned long delayStart = micros();
+  delayMicroseconds(1000);
+  unsigned long delayElapsed = micros() - delayStart;
+  long delayError = abs((long)delayElapsed - 1000);
+
+  if (microsResolution <= 2 && delayError <= 5) {
+    gMinBenchUs = 5000;
+  } else if (microsResolution <= 8 && delayError <= 25) {
+    gMinBenchUs = 20000;
+  } else {
+    gMinBenchUs = 50000;
+  }
 }
 
 // ==================== CPU BENCHMARKS ====================
@@ -649,7 +674,7 @@ void benchmarkFloatOps() {
 void benchmarkStringOps() {
   printHeader("CPU: STRING OPERATIONS");
 
-  const uint32_t minDurationMs = 5;
+  const uint32_t minDurationMs = max(5UL, (gMinBenchUs + 999UL) / 1000UL);
 
   // String concatenation
   String testString = "";
@@ -1072,7 +1097,7 @@ void benchmarkDigitalIO() {
 void benchmarkAnalogIO() {
   printHeader("I/O: ANALOG OPERATIONS");
 
-  const uint32_t minDurationMs = 5;
+  const uint32_t minDurationMs = max(5UL, (gMinBenchUs + 999UL) / 1000UL);
 
 // Find analog pins
 #if defined(ESP32)
@@ -2065,6 +2090,8 @@ void printSystemInfo() {
 void setup() {
   Serial.begin(SERIAL_BAUD);
   delay(2000);  // Wait for serial connection
+
+  calibrateBenchmarkTime();
 
   Serial.println();
   Serial.println();


### PR DESCRIPTION
### Motivation
- Microbenchmarks can be skewed by coarse `micros()` resolution or inaccuracy of short delays, so a dynamic minimum measurement window is needed.
- Provide a simple automatic calibration to pick an appropriate minimum benchmark duration for different boards and timer behaviors.

### Description
- Add global variable `gMinBenchUs` (default `20000`) to hold the calibrated minimum microsecond duration.
- Implement `calibrateBenchmarkTime()` which measures `micros()` resolution and the error of a `delayMicroseconds(1000)` call and sets `gMinBenchUs` to `5000`, `20000`, or `50000` based on the measured values.
- Use the calibrated minimum when running timed microbenchmarks by replacing fixed `5 ms` windows with `minDurationMs = max(5UL, (gMinBenchUs + 999UL) / 1000UL)` so all `runTimedLoop` invocations use the adjusted value.
- Invoke `calibrateBenchmarkTime()` early in `setup()` so subsequent benchmarks use the calibrated minimum.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979c6e350e08331a43fa421df65e37c)