### PR TITLE
Fix ESP32 Nano build by moving helper types to header and adding LEDC API compatibility

### DIFF
--- a/BenchmarkHelpers.h
+++ b/BenchmarkHelpers.h
@@ -1,0 +1,50 @@
+#ifndef BENCHMARK_HELPERS_H
+#define BENCHMARK_HELPERS_H
+
+#include <Arduino.h>
+
+struct MinDurationResult {
+  uint32_t ops;
+  unsigned long elapsedUs;
+};
+
+template <typename Func>
+MinDurationResult runForAtLeastUs(unsigned long minUs, Func fn) {
+  MinDurationResult result = {};
+  unsigned long start = micros();
+  unsigned long elapsed = 0;
+  do {
+    result.ops += fn();
+#if defined(ESP32) || defined(ESP8266) || defined(ARDUINO_ARCH_RP2040)
+    yield();
+#endif
+    elapsed = micros() - start;
+  } while (elapsed < minUs);
+  result.elapsedUs = elapsed;
+  return result;
+}
+
+struct TimedLoopResult {
+  unsigned long elapsedMicros;
+  uint32_t iterations;
+  uint32_t totalOps;
+  float opsPerMs;
+};
+
+template <typename Func>
+TimedLoopResult runTimedLoop(uint32_t minDurationMs, uint32_t opsPerIteration, Func func) {
+  TimedLoopResult result = {};
+  unsigned long start = micros();
+  unsigned long elapsed = 0;
+  do {
+    func();
+    result.iterations++;
+    result.totalOps += opsPerIteration;
+    elapsed = micros() - start;
+  } while (elapsed < (minDurationMs * 1000UL));
+  result.elapsedMicros = elapsed;
+  result.opsPerMs = (result.totalOps * 1000.0f) / result.elapsedMicros;
+  return result;
+}
+
+#endif


### PR DESCRIPTION
### Motivation
- Fix compile errors on Arduino Nano ESP32 caused by missing type names from Arduino's auto-prototyping (e.g. `'MinDurationResult' does not name a type`).
- Ensure PWM/LEDC code works across ESP32 Arduino core versions that changed the LEDC API.

### Description
- Extracted benchmark helper types and template functions (`MinDurationResult`, `TimedLoopResult`, `runForAtLeastUs`, `runTimedLoop`) into a new header `BenchmarkHelpers.h` and included it from `UniversalArduinoBenchmark.ino` to avoid prototype ordering issues. 
- Added `#include <Arduino.h>` in the new header so the helper code has Arduino types and `micros()`/`yield()` available. 
- Updated ESP32 PWM setup to detect newer cores and use the new `ledcAttach(analogOutPin, pwmFreq, pwmResolution)` path when `ESP_ARDUINO_VERSION_MAJOR >= 3`, while keeping the legacy `ledcSetup`/`ledcAttachPin` and `ledcWrite(pwmChannel, ...)` behavior for older cores. 
- Removed the duplicated helper definitions from the `.ino` file and adjusted `ledcWrite` calls to use the appropriate API per core version.

### Testing
- No automated tests were run on the modified code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979cb4be9f08331a3d75bd0a6a68bc5)