### PR TITLE
Time-based yield servicing in CPU stress test

### DIFF
--- a/UniversalArduinoBenchmark.ino
+++ b/UniversalArduinoBenchmark.ino
@@ -466,6 +466,7 @@ void benchmarkCPUStress() {
 
   // CPU stress test - run all cores
   unsigned long stressStart = millis();
+  unsigned long lastService = millis();
   unsigned long iterations = 0;
   volatile float result = 1.0f;
   const float twoPi = 6.2831853f;
@@ -480,10 +481,14 @@ void benchmarkCPUStress() {
     }
 
     // Periodic yield to prevent watchdog timeout (but don't print)
-    if ((iterations % 10000) == 0) {
+    if (millis() - lastService >= 5) {
 #if defined(ARDUINO_ARCH_RP2040) || defined(ESP32) || defined(ESP8266)
       yield();
+#if defined(ESP32) || defined(ESP8266)
+      delay(0);
 #endif
+#endif
+      lastService = millis();
     }
   }
 


### PR DESCRIPTION
### Motivation
- Prevent USB CDC stalls and apparent freezes during the 10s CPU stress by servicing `yield()` on a time interval instead of tying it to the loop iteration count.

### Description
- Modified `benchmarkCPUStress()` in `UniversalArduinoBenchmark.ino` to introduce `unsigned long lastService = millis();` and replace the `iterations % 10000` check with a time-based check `if (millis() - lastService >= 5)`.
- Under the existing platform guards (`ARDUINO_ARCH_RP2040`, `ESP32`, `ESP8266`) the code now calls `yield()` and additionally calls `delay(0)` for `ESP32`/`ESP8266`, then updates `lastService` after servicing.
- Preserves the original stress workload and overall 10-second duration.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979cdc77c3c8331adc7065233aeba96)