### PR TITLE
Fix digital IO speedup reporting and ESP32 register toggles

### DIFF
--- a/UniversalArduinoBenchmark.ino
+++ b/UniversalArduinoBenchmark.ino
@@ -1109,8 +1109,13 @@ void benchmarkDigitalIO() {
     TimedLoopResult regResult = runTimedLoop(minDurationMs, 2000, [&]() {
       for (int i = 0; i < 1000; i++) {
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 0, 0)
-        gpio_set_level((gpio_num_t)testPin, 1);
-        gpio_set_level((gpio_num_t)testPin, 0);
+        if (testPin < 32) {
+          GPIO.out_w1ts = 1u << testPin;
+          GPIO.out_w1tc = 1u << testPin;
+        } else {
+          GPIO.out1_w1ts.data = 1u << (testPin - 32);
+          GPIO.out1_w1tc.data = 1u << (testPin - 32);
+        }
 #else
         digitalWrite(testPin, HIGH);
         digitalWrite(testPin, LOW);
@@ -1168,7 +1173,7 @@ void benchmarkDigitalIO() {
   Serial.print(kJitterTrials);
   Serial.println(F(" trials)"));
   Serial.print(F("Speedup: "));
-  Serial.print((float)writeTime / portElapsedMicros);
+  Serial.print(portOpsPerMs / writeOpsPerMs);
   Serial.println(F("x faster"));
 #endif
 
@@ -1183,7 +1188,7 @@ void benchmarkDigitalIO() {
   Serial.print(kJitterTrials);
   Serial.println(F(" trials)"));
   Serial.print(F("Speedup: "));
-  Serial.print((float)writeTime / regElapsedMicros);
+  Serial.print(regOpsPerMs / writeOpsPerMs);
   Serial.println(F("x faster"));
 #endif
 }


### PR DESCRIPTION
### Motivation

- The digital I/O benchmark reported a misleading "Speedup" by comparing elapsed times instead of comparable rates, producing values <1 for faster paths. 
- The ESP32 direct-register path used `gpio_set_level()` which is not the fastest W1TS/W1TC register toggle path available on modern ESP-IDF builds. 
- The goal is to make the direct-register path faster and to report a correct, intuitive speedup (>1x when direct register is faster) while keeping the `digitalWrite()` loop unchanged for a fair comparison.

### Description

- Replaced the ESP32 fast-path calls under `#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 0, 0)` with direct W1TS/W1TC register toggles using `GPIO.out_w1ts`/`GPIO.out_w1tc` for pins < 32 and `GPIO.out1_w1ts.data`/`GPIO.out1_w1tc.data` for pins >= 32 inside the `UniversalArduinoBenchmark.ino` digital I/O benchmark. 
- Preserved the `digitalWrite()` fallback under the older preprocessor branch so the `digitalWrite()` loop remains unchanged and comparable. 
- Changed the "Speedup" printout to compute the ratio using operations-per-millisecond values (for example `regOpsPerMs / writeOpsPerMs` and `portOpsPerMs / writeOpsPerMs`) so faster methods report values >1x. 
- All edits are contained in `UniversalArduinoBenchmark.ino` in the digital I/O benchmarking section and are guarded by the existing `#ifdef`/`#if` conditionals.

### Testing

- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979d16b33648331aab3191a7222bb5f)