### PR TITLE
Fix ESP32 GPIO register includes

### DIFF
--- a/UniversalArduinoBenchmark.ino
+++ b/UniversalArduinoBenchmark.ino
@@ -53,6 +53,8 @@
 #include <BLEDevice.h>
 #include <BLEScan.h>
 #include <driver/gpio.h>
+#include "soc/gpio_struct.h"
+#include "soc/gpio_reg.h"
 #define EEPROM_SIZE 512
 
 // ESP8266 Family


### PR DESCRIPTION
### Motivation
- Resolve compilation error `'GPIO' was not declared` for ESP32 direct register writes by making the SOC GPIO symbols available.

### Description
- Add `#include "soc/gpio_struct.h"` and `#include "soc/gpio_reg.h"` to the ESP32 branch in `UniversalArduinoBenchmark.ino` so the `GPIO` symbols used for direct register writes are defined.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979d26ded3c8331b90c4acb9410e969)