### PR TITLE
Use microsecond timing for secure storage benchmark

### DIFF
--- a/UniversalArduinoBenchmark.ino
+++ b/UniversalArduinoBenchmark.ino
@@ -2132,19 +2132,21 @@ void benchmarkSoftwareATSE() {
     testConfig[i] = i & 0xFF;
   }
   
-  unsigned long writeStart = millis();
+  unsigned long writeStart = micros();
   bool writeSuccess = false;
   
   if (SATSE.writeConfiguration(testConfig) == 1) {
-    unsigned long writeTime = millis() - writeStart;
+    unsigned long writeTime = micros() - writeStart;
     writeSuccess = true;
     
-    Serial.print(F("Config write (ms): "));
+    Serial.print(F("Config write (\xC2\xB5s): "));
     Serial.println(writeTime);
+    Serial.print(F("  (ms): "));
+    Serial.println(writeTime / 1000.0f, 3);
     
     Serial.print(F("  Write speed: "));
     if (writeTime > 0) {
-      Serial.print(256000.0f / writeTime, 2);
+      Serial.print(256.0f * 1000000.0f / writeTime, 2);
       Serial.println(F(" bytes/sec"));
     } else {
       Serial.println(F("N/A (too fast)"));


### PR DESCRIPTION
### Motivation
- Improve precision of the Secure Storage configuration write benchmark by switching from `millis()` to `micros()` so elapsed time is measured in microseconds and coarse rounding/divide-by-zero risks are reduced. 
- Provide clearer output by printing the elapsed time in microseconds and an additional converted milliseconds value for readability.

### Description
- Replaced `millis()` with `micros()` for `writeStart` and `writeTime` in `UniversalArduinoBenchmark.ino` and updated the printed label to `Config write (μs):` with an extra ` (ms): ` line showing `writeTime / 1000.0f` at 3 decimal places. 
- Recomputed throughput using microsecond timing with `256.0f * 1000000.0f / writeTime` bytes/sec and retained the `if (writeTime > 0)` guard to avoid division by zero.

### Testing
- No automated tests or CI were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979ed60f918833188584d94981f757c)