### PR TITLE
Add RP2040 Pico dual-core benchmark and scaling output

### DIFF
--- a/UniversalArduinoBenchmark.ino
+++ b/UniversalArduinoBenchmark.ino
@@ -92,6 +92,9 @@
 #define HAS_TEMPERATURE
 // RP2040 hardware register access
 #include "hardware/gpio.h"
+#if defined(ARDUINO_PICO_MAJOR_VERSION)
+#include "pico/multicore.h"
+#endif
 
 // Renesas RA4M1 (Arduino Uno R4 WiFi & Minima)
 #elif defined(ARDUINO_UNOR4_WIFI)
@@ -1961,6 +1964,25 @@ void core1Task(void* parameter) {
 }
 #endif
 
+#if defined(ARDUINO_ARCH_RP2040) && defined(ARDUINO_PICO_MAJOR_VERSION)
+volatile unsigned long rp2040Core0Count = 0;
+volatile unsigned long rp2040Core1Count = 0;
+volatile bool rp2040TestRunning = false;
+volatile bool rp2040Core1Ready = false;
+
+void rp2040Core1Task() {
+  volatile uint32_t accumulator = 0;
+  rp2040Core1Ready = true;
+  while (true) {
+    if (rp2040TestRunning) {
+      rp2040Core1Count++;
+      accumulator += 3;
+      accumulator ^= (accumulator << 1);
+    }
+  }
+}
+#endif
+
 void benchmarkMultiCore() {
   printHeader("MULTI-CORE: Parallel Performance");
 
@@ -2012,6 +2034,46 @@ void benchmarkMultiCore() {
 
 #elif defined(ARDUINO_ARCH_RP2040)
   Serial.println(F("RP2040 Dual-Core Test"));
+#if defined(ARDUINO_PICO_MAJOR_VERSION)
+  Serial.println(F("Running dual-core workload for 1 second..."));
+
+  rp2040Core0Count = 0;
+  rp2040Core1Count = 0;
+  rp2040TestRunning = false;
+  rp2040Core1Ready = false;
+
+  multicore_reset_core1();
+  multicore_launch_core1(rp2040Core1Task);
+
+  unsigned long readyStart = millis();
+  while (!rp2040Core1Ready && millis() - readyStart < 200) {
+    delay(1);
+  }
+
+  rp2040TestRunning = true;
+  unsigned long start = millis();
+  volatile uint32_t accumulator = 0;
+  while (millis() - start < 1000) {
+    rp2040Core0Count++;
+    accumulator += 3;
+    accumulator ^= (accumulator << 1);
+  }
+  rp2040TestRunning = false;
+
+  unsigned long total = rp2040Core0Count + rp2040Core1Count;
+  unsigned long dominant = max(rp2040Core0Count, rp2040Core1Count);
+  float scaling = dominant > 0 ? (float)total / (float)dominant : 0.0f;
+
+  Serial.print(F("Core 0 iterations: "));
+  Serial.println(rp2040Core0Count);
+  Serial.print(F("Core 1 iterations: "));
+  Serial.println(rp2040Core1Count);
+  Serial.print(F("Total iterations: "));
+  Serial.println(total);
+  Serial.print(F("Scaling efficiency: "));
+  Serial.print(scaling, 2);
+  Serial.println(F("x"));
+#else
   Serial.println(F("Single core performance:"));
 
   volatile unsigned long count = 0;
@@ -2023,6 +2085,7 @@ void benchmarkMultiCore() {
   Serial.print(F("Iterations in 1 second: "));
   Serial.println(count);
   Serial.println(F("Note: Full dual-core requires multicore library"));
+#endif
 #endif
 }
 #endif


### PR DESCRIPTION
### Motivation

- Provide a more informative RP2040 multicore benchmark that runs a fixed workload on both cores concurrently and reports per-core work counts.
- Make it possible to quantify dual-core scaling and detect contention instead of only reporting single-core iteration counts.
- Preserve the existing single-core fallback when Pico multicore APIs are not available.

### Description

- Add conditional inclusion of the Pico multicore header with `#include "pico/multicore.h"` when `ARDUINO_PICO_MAJOR_VERSION` is defined in `UniversalArduinoBenchmark.ino`.
- Add volatile counters and flags `rp2040Core0Count`, `rp2040Core1Count`, `rp2040TestRunning`, and `rp2040Core1Ready`, plus a `rp2040Core1Task()` worker for core1.
- In `benchmarkMultiCore()` use `multicore_reset_core1()` and `multicore_launch_core1(rp2040Core1Task)` to run a 1-second parallel workload, then print `Core 0 iterations`, `Core 1 iterations`, `Total iterations`, and `Scaling efficiency` (as an `x` factor).
- Keep the previous single-core measurement and the note about needing the multicore library when `ARDUINO_PICO_MAJOR_VERSION` is not defined.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979f16dbb9c833185d0915773eff8f9)