### PR TITLE
Use `MBEDTLS_VERSION_NUMBER` to detect mbed TLS v3 for PBKDF2 call

### DIFF
--- a/UniversalArduinoBenchmark.ino
+++ b/UniversalArduinoBenchmark.ino
@@ -1964,7 +1964,7 @@ void benchmarkESP32Crypto() {
   const uint32_t pbkdf2Iterations = 500;
 
   TimedLoopResult pbkdf2Result = runTimedLoop(minDurationMs, 1, [&]() {
-#if defined(MBEDTLS_VERSION_MAJOR) && MBEDTLS_VERSION_MAJOR >= 3
+#if defined(MBEDTLS_VERSION_NUMBER) && MBEDTLS_VERSION_NUMBER >= 0x03000000
     if (mbedtls_pkcs5_pbkdf2_hmac_ext(MBEDTLS_MD_SHA256,
                                      reinterpret_cast<const unsigned char *>(password),
                                      strlen(password),


### PR DESCRIPTION
### Motivation
- The existing preprocessor check used `MBEDTLS_VERSION_MAJOR` which may not be reliably defined by newer mbed TLS headers, so switch to the canonical `MBEDTLS_VERSION_NUMBER` to detect v3 and select the correct PBKDF2 API.

### Description
- Replace the preprocessor condition from `#if defined(MBEDTLS_VERSION_MAJOR) && MBEDTLS_VERSION_MAJOR >= 3` to `#if defined(MBEDTLS_VERSION_NUMBER) && MBEDTLS_VERSION_NUMBER >= 0x03000000` so the code uses `mbedtls_pkcs5_pbkdf2_hmac_ext` on mbed TLS v3 and falls back to the older `mbedtls_pkcs5_pbkdf2_hmac` path otherwise.

### Testing
- No automated tests were run for this change (`not run`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979f7bfd628833199ffcf6ec1698ddf)