### PR TITLE
Add platform-specific yield() to timed benchmark loop

### DIFF
--- a/BenchmarkHelpers.h
+++ b/BenchmarkHelpers.h
@@ -40,6 +40,9 @@ TimedLoopResult runTimedLoop(uint32_t minDurationMs, uint32_t opsPerIteration, F
     func();
     result.iterations++;
     result.totalOps += opsPerIteration;
+#if defined(ESP32) || defined(ESP8266) || defined(ARDUINO_ARCH_RP2040)
+    yield();
+#endif
     elapsed = micros() - start;
   } while (elapsed < (minDurationMs * 1000UL));
   result.elapsedMicros = elapsed;


### PR DESCRIPTION
### Motivation
- Prevent watchdog stalls and allow cooperative multitasking on ESP32/ESP8266/RP2040 during long-running benchmarks by making the timed loop yield periodically to background tasks; `runForAtLeastUs` already used `yield()`, so `runTimedLoop` is aligned for parity.

### Description
- Insert a platform-guarded `yield()` call inside `runTimedLoop` in `BenchmarkHelpers.h` (guarded by `#if defined(ESP32) || defined(ESP8266) || defined(ARDUINO_ARCH_RP2040)`) so long benchmarks won't block background processing.

### Testing
- No automated tests were run on this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979f950eb5083318d007fd84c0145e7)