### PR TITLE
Add crypto benchmark progress and timeout

### DIFF
--- a/UniversalArduinoBenchmark.ino
+++ b/UniversalArduinoBenchmark.ino
@@ -1857,10 +1857,22 @@ void benchmarkESP32Crypto() {
   uint8_t digest[64];
   char hexDigest[129];
   volatile uint32_t checksum = 0;
+  uint32_t lastProgressMs = millis();
+  const uint32_t maxCryptoMs = 15000;
+  const uint32_t cryptoStartMs = lastProgressMs;
+  bool cryptoTimedOut = false;
   auto benchYield = []() {
 #if defined(ESP32) || defined(ESP8266) || defined(ARDUINO_ARCH_RP2040)
     yield();
 #endif
+  };
+  auto checkCryptoTimeout = [&]() -> bool {
+    if (millis() - cryptoStartMs > maxCryptoMs) {
+      Serial.println(F("Warning: crypto benchmark timed out."));
+      cryptoTimedOut = true;
+      return true;
+    }
+    return false;
   };
 
   auto toHex = [&](const uint8_t *data, size_t len, char *out) {
@@ -1911,8 +1923,12 @@ void benchmarkESP32Crypto() {
   Serial.println(F("SHA3-256: not available in this build"));
 #endif
 
+  Serial.println(F("...running HEX encode"));
   TimedLoopResult hexResult = runTimedLoop(minDurationMs, 20, [&]() {
     for (uint8_t i = 0; i < 20; i++) {
+      if (checkCryptoTimeout()) {
+        return;
+      }
       toHex(input, inputSize, hexDigest);
       checksum += hexDigest[0];
       if ((i % 5) == 0) {
@@ -1920,9 +1936,16 @@ void benchmarkESP32Crypto() {
       }
     }
   });
+  if (cryptoTimedOut) {
+    return;
+  }
 
+  Serial.println(F("...running MD5"));
   TimedLoopResult md5Result = runTimedLoop(minDurationMs, 10, [&]() {
     for (uint8_t i = 0; i < 10; i++) {
+      if (checkCryptoTimeout()) {
+        return;
+      }
       benchmarkMd5(input, inputSize, digest);
       checksum += digest[0];
       if ((i % 3) == 0) {
@@ -1930,9 +1953,16 @@ void benchmarkESP32Crypto() {
       }
     }
   });
+  if (cryptoTimedOut) {
+    return;
+  }
 
+  Serial.println(F("...running SHA1"));
   TimedLoopResult sha1Result = runTimedLoop(minDurationMs, 10, [&]() {
     for (uint8_t i = 0; i < 10; i++) {
+      if (checkCryptoTimeout()) {
+        return;
+      }
       benchmarkSha1(input, inputSize, digest);
       checksum += digest[0];
       if ((i % 3) == 0) {
@@ -1940,9 +1970,16 @@ void benchmarkESP32Crypto() {
       }
     }
   });
+  if (cryptoTimedOut) {
+    return;
+  }
 
+  Serial.println(F("...running SHA256"));
   TimedLoopResult sha256Result = runTimedLoop(minDurationMs, 10, [&]() {
     for (uint8_t i = 0; i < 10; i++) {
+      if (checkCryptoTimeout()) {
+        return;
+      }
       benchmarkSha256(input, inputSize, digest);
       checksum += digest[0];
       if ((i % 3) == 0) {
@@ -1950,9 +1987,16 @@ void benchmarkESP32Crypto() {
       }
     }
   });
+  if (cryptoTimedOut) {
+    return;
+  }
 
+  Serial.println(F("...running SHA512"));
   TimedLoopResult sha512Result = runTimedLoop(minDurationMs, 10, [&]() {
     for (uint8_t i = 0; i < 10; i++) {
+      if (checkCryptoTimeout()) {
+        return;
+      }
       benchmarkSha512(input, inputSize, digest);
       checksum += digest[0];
       if ((i % 2) == 0) {
@@ -1960,10 +2004,17 @@ void benchmarkESP32Crypto() {
       }
     }
   });
+  if (cryptoTimedOut) {
+    return;
+  }
 
 #if defined(MBEDTLS_SHA3_C)
+  Serial.println(F("...running SHA3-256"));
   TimedLoopResult sha3Result = runTimedLoop(minDurationMs, 5, [&]() {
     for (uint8_t i = 0; i < 5; i++) {
+      if (checkCryptoTimeout()) {
+        return;
+      }
       mbedtls_sha3_context sha3;
       mbedtls_sha3_init(&sha3);
       mbedtls_sha3_starts(&sha3, 256);
@@ -1974,6 +2025,9 @@ void benchmarkESP32Crypto() {
       benchYield();
     }
   });
+  if (cryptoTimedOut) {
+    return;
+  }
 #endif
 
   const uint8_t saltSize = 16;
@@ -1984,7 +2038,11 @@ void benchmarkESP32Crypto() {
   const char *password = "esp32-benchmark";
   const uint32_t pbkdf2Iterations = 500;
 
+  Serial.println(F("...running PBKDF2-HMAC-SHA256"));
   TimedLoopResult pbkdf2Result = runTimedLoop(minDurationMs, 1, [&]() {
+    if (checkCryptoTimeout()) {
+      return;
+    }
 #if defined(MBEDTLS_VERSION_NUMBER) && MBEDTLS_VERSION_NUMBER >= 0x03000000
     if (mbedtls_pkcs5_pbkdf2_hmac_ext(MBEDTLS_MD_SHA256,
                                      reinterpret_cast<const unsigned char *>(password),
@@ -2014,8 +2072,15 @@ void benchmarkESP32Crypto() {
     }
     mbedtls_md_free(&ctx);
 #endif
+    if (millis() - lastProgressMs > 1000) {
+      Serial.print('.');
+      lastProgressMs = millis();
+    }
     benchYield();
   });
+  if (cryptoTimedOut) {
+    return;
+  }
 
   Serial.print(F("Checksum: "));
   Serial.println(checksum);


### PR DESCRIPTION
### Motivation
- Prevent long-running crypto timed loops from hanging the benchmark by adding a global timeout and progress indicators.
- Provide visible progress feedback during long PBKDF2 runs so users can see activity during slow operations.

### Description
- Add timing and state variables `lastProgressMs`, `maxCryptoMs`, `cryptoStartMs`, and `cryptoTimedOut` and a helper lambda `checkCryptoTimeout()` to track and enforce a crypto benchmark timeout of `15000` ms.
- Print a short progress message before each crypto timed loop (`HEX`, `MD5`, `SHA1`, `SHA256`, `SHA512`, `SHA3-256` when available, and `PBKDF2-HMAC-SHA256`).
- Call `checkCryptoTimeout()` inside each timed-loop body and return early from `benchmarkESP32Crypto()` with a warning if the total crypto time exceeds `maxCryptoMs`.
- Emit a dot progress update during the PBKDF2 loop when `millis() - lastProgressMs > 1000` to indicate ongoing work.

### Testing
- No automated tests were run on this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979fecd7eb48331b9fb74e756c7b67e)