### PR TITLE
Add Arduino Uno Q (STM32U5) board detection and feature flags

### DIFF
--- a/UniversalArduinoBenchmark.ino
+++ b/UniversalArduinoBenchmark.ino
@@ -270,6 +270,24 @@
 #include <EEPROM.h>
 #define BOARD_AVR
 
+// Arduino Uno Q (STM32U585 MCU target)
+#elif defined(ARDUINO_UNO_Q_MCU) || defined(ARDUINO_UNO_Q) || defined(STM32U5xx) || defined(STM32U585xx)
+#define BOARD_NAME "Arduino Uno Q (MCU)"
+#define BOARD_STM32U5
+#if defined(__FPU_PRESENT) && (__FPU_PRESENT == 1)
+#define HAS_FPU
+#endif
+#if defined(RNG) || defined(RNG_BASE)
+#define HAS_RNG
+#endif
+#include <EEPROM.h>
+#if __has_include("stm32u5xx_hal.h")
+#include "stm32u5xx_hal.h"
+#endif
+#if __has_include("stm32u5xx_hal_rng.h")
+#include "stm32u5xx_hal_rng.h"
+#endif
+
 // STM32 Family (Blue Pill, Black Pill, Nucleo)
 #elif defined(ARDUINO_ARCH_STM32)
 #if defined(ARDUINO_BLUEPILL_F103C8) || defined(ARDUINO_BLUEPILL_F103CB)


### PR DESCRIPTION
### Motivation
- Add detection for the Arduino Uno Q MCU target (STM32U585) so the benchmark can recognize the board and enable MCU-only features such as FPU and RNG when available.
- Ensure STM32U5-specific headers are only included when the core exposes them to avoid breaking other targets.

### Description
- Added a new board-detection `#elif` branch that triggers on `ARDUINO_UNO_Q_MCU`, `ARDUINO_UNO_Q`, `STM32U5xx`, or `STM32U585xx` and sets `BOARD_NAME` to `"Arduino Uno Q (MCU)"`.
- Defined `BOARD_STM32U5` and conditionally defined `HAS_FPU` when `__FPU_PRESENT == 1` and `HAS_RNG` when `RNG` or `RNG_BASE` are present.
- Included `<EEPROM.h>` and added conditional includes for `stm32u5xx_hal.h` and `stm32u5xx_hal_rng.h` using `__has_include` so these headers are only pulled in when available.
- Placed the new branch inside the existing board-detection block so downstream benchmark sections can use the new macros for MCU-only features.

### Testing
- No automated tests were run on this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a836221808331a48bc0d7009d5f6d)