### PR TITLE
Guard HEXBuilder include for ESP32 and add non-ESP32 hex fallback

### DIFF
--- a/UniversalArduinoBenchmark.ino
+++ b/UniversalArduinoBenchmark.ino
@@ -368,7 +368,9 @@
 #endif
 
 #include "BenchmarkHelpers.h"
+#if defined(ESP32)
 #include <HEXBuilder.h>
+#endif
 
 // ==================== GLOBAL VARIABLES ====================
 uint8_t testBuffer[256];
@@ -1907,8 +1909,19 @@ void benchmarkESP32Crypto() {
     if (outCapacity < requiredSize) {
       return false;
     }
+#if defined(ESP32)
     size_t written = HEXBuilder::bytes2hex(out, outCapacity, data, len);
     return written >= requiredSize;
+#else
+    static const char kHexChars[] = "0123456789abcdef";
+    for (size_t i = 0; i < len; ++i) {
+      const uint8_t byteValue = data[i];
+      out[i * 2] = kHexChars[(byteValue >> 4) & 0x0F];
+      out[(i * 2) + 1] = kHexChars[byteValue & 0x0F];
+    }
+    out[len * 2] = '\0';
+    return true;
+#endif
   };
 
   const uint32_t minDurationMs = max(5UL, (gMinBenchUs + 999UL) / 1000UL);


### PR DESCRIPTION
### Motivation
- Prevent pulling in `HEXBuilder.h` on non-ESP32 builds to avoid unnecessary/unsupported dependencies and compilation issues.
- Ensure crypto digest formatting continues to work on non-ESP32 boards by providing a portable hex conversion fallback.

### Description
- Wrapped the `#include <HEXBuilder.h>` with an `#if defined(ESP32)` guard in `UniversalArduinoBenchmark.ino`.
- Replaced the global `toHex` lambda to call `HEXBuilder::bytes2hex` on ESP32 and use a small manual hex conversion on other boards.
- Kept the same output buffer sizing and behavior so callers and hex buffer checks remain unchanged.
- Changes were committed to `UniversalArduinoBenchmark.ino`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a88e45b6883319a7c4aa2fcd457e5)