### PR TITLE
Remove microSD feature note for Multiduino

### DIFF
--- a/UniversalArduinoBenchmark.ino
+++ b/UniversalArduinoBenchmark.ino
@@ -216,12 +216,8 @@
 #include <EEPROM.h>
 #include <Wire.h>
 #include <RTClib.h>  // Adafruit RTClib for DS1307
-#include <SD.h>
-#include <SPI.h>
 #define BOARD_AVR
 #define HAS_RTC
-#define HAS_SD_CARD
-#define SD_CS_PIN 10  // Adjust to your actual SD card CS pin
 #define RTC_I2C_ADDRESS 0x68  // Standard DS1307 I2C address
 
 // Arduino Uno
@@ -411,12 +407,6 @@ const uint8_t kJitterTrials = 5;
 RTC_DS1307 rtc;
 #endif
 
-#ifdef HAS_SD_CARD
-File testFile;
-const char* TEST_FILENAME = "bench.dat";
-const size_t SD_BUFFER_SIZE = 512;  // Standard SD block size
-uint8_t sdBuffer[SD_BUFFER_SIZE];
-#endif
 
 // ==================== HELPER FUNCTIONS ====================
 
@@ -3548,231 +3538,6 @@ void benchmarkRTC() {
 }
 #endif  // HAS_RTC
 
-#ifdef HAS_SD_CARD
-void benchmarkSDCard() {
-  printHeader("SD CARD BENCHMARK");
-  
-  // Initialize SD card
-  Serial.print(F("Initializing SD card on CS pin "));
-  Serial.print(SD_CS_PIN);
-  Serial.println(F("..."));
-  
-  if (!SD.begin(SD_CS_PIN)) {
-    Serial.println(F("ERROR: SD card initialization failed!"));
-    Serial.println(F("Check:"));
-    Serial.println(F("  - SD card is inserted"));
-    Serial.println(F("  - CS pin is correct"));
-    Serial.println(F("  - Wiring: MOSI->11, MISO->12, SCK->13"));
-    Serial.println();
-    return;
-  }
-  
-  Serial.println(F("SD card initialized successfully"));
-  Serial.println();
-  
-  // Get card info
-  Serial.println(F("Card Information:"));
-  uint8_t cardType = SD.cardType();
-  Serial.print(F("  Type: "));
-  switch(cardType) {
-    case SD_CARD_TYPE_SD1:
-      Serial.println(F("SD1"));
-      break;
-    case SD_CARD_TYPE_SD2:
-      Serial.println(F("SD2"));
-      break;
-    case SD_CARD_TYPE_SDHC:
-      Serial.println(F("SDHC"));
-      break;
-    default:
-      Serial.println(F("Unknown"));
-  }
-  
-  uint32_t cardSize = SD.cardSize() / (1024 * 1024);
-  Serial.print(F("  Size: "));
-  Serial.print(cardSize);
-  Serial.println(F(" MB"));
-  
-  uint32_t totalBytes = SD.totalBytes() / (1024 * 1024);
-  Serial.print(F("  Total: "));
-  Serial.print(totalBytes);
-  Serial.println(F(" MB"));
-  
-  uint32_t usedBytes = SD.usedBytes() / 1024;
-  Serial.print(F("  Used: "));
-  Serial.print(usedBytes);
-  Serial.println(F(" KB"));
-  Serial.println();
-  
-  // Initialize test buffer with pattern
-  for (size_t i = 0; i < SD_BUFFER_SIZE; i++) {
-    sdBuffer[i] = (uint8_t)(i & 0xFF);
-  }
-  
-  // Benchmark 1: Sequential Write
-  Serial.println(F("Test: Sequential Write (512-byte blocks)"));
-  
-  // Remove old test file if exists
-  if (SD.exists(TEST_FILENAME)) {
-    SD.remove(TEST_FILENAME);
-  }
-  
-  testFile = SD.open(TEST_FILENAME, FILE_WRITE);
-  if (!testFile) {
-    Serial.println(F("ERROR: Could not create test file"));
-    return;
-  }
-  
-  const uint32_t writeBlocks = 100;  // 51.2 KB total
-  unsigned long startTime = micros();
-  
-  for (uint32_t i = 0; i < writeBlocks; i++) {
-    testFile.write(sdBuffer, SD_BUFFER_SIZE);
-  }
-  testFile.flush();  // Ensure data is written
-  
-  unsigned long elapsed = micros() - startTime;
-  testFile.close();
-  
-  uint32_t bytesWritten = writeBlocks * SD_BUFFER_SIZE;
-  float writeSpeed = (bytesWritten / 1024.0f) / (elapsed / 1000000.0f);
-  
-  Serial.print(F("  Wrote: "));
-  Serial.print(bytesWritten / 1024.0f, 2);
-  Serial.print(F(" KB in "));
-  Serial.print(elapsed / 1000.0f, 2);
-  Serial.println(F(" ms"));
-  Serial.print(F("  Speed: "));
-  Serial.print(writeSpeed, 2);
-  Serial.println(F(" KB/s"));
-  Serial.println();
-  
-  // Benchmark 2: Sequential Read
-  Serial.println(F("Test: Sequential Read (512-byte blocks)"));
-  
-  testFile = SD.open(TEST_FILENAME, FILE_READ);
-  if (!testFile) {
-    Serial.println(F("ERROR: Could not open test file for reading"));
-    return;
-  }
-  
-  const uint32_t readBlocks = 100;
-  volatile uint32_t readChecksum = 0;
-  startTime = micros();
-  
-  for (uint32_t i = 0; i < readBlocks; i++) {
-    size_t bytesRead = testFile.read(sdBuffer, SD_BUFFER_SIZE);
-    for (size_t j = 0; j < bytesRead; j++) {
-      readChecksum += sdBuffer[j];
-    }
-  }
-  
-  elapsed = micros() - startTime;
-  testFile.close();
-  
-  uint32_t bytesRead = readBlocks * SD_BUFFER_SIZE;
-  float readSpeed = (bytesRead / 1024.0f) / (elapsed / 1000000.0f);
-  
-  Serial.print(F("  Read: "));
-  Serial.print(bytesRead / 1024.0f, 2);
-  Serial.print(F(" KB in "));
-  Serial.print(elapsed / 1000.0f, 2);
-  Serial.println(F(" ms"));
-  Serial.print(F("  Speed: "));
-  Serial.print(readSpeed, 2);
-  Serial.println(F(" KB/s"));
-  Serial.print(F("  Checksum: 0x"));
-  Serial.println((unsigned long)readChecksum, HEX);
-  Serial.println();
-  
-  // Benchmark 3: Random Access (Seek)
-  Serial.println(F("Test: Random Access (Seek)"));
-  
-  testFile = SD.open(TEST_FILENAME, FILE_READ);
-  if (!testFile) {
-    Serial.println(F("ERROR: Could not open test file"));
-    return;
-  }
-  
-  const uint32_t seekCount = 100;
-  volatile uint32_t seekChecksum = 0;
-  startTime = micros();
-  
-  for (uint32_t i = 0; i < seekCount; i++) {
-    // Seek to random position
-    uint32_t pos = (i * 123) % (bytesWritten - SD_BUFFER_SIZE);
-    testFile.seek(pos);
-    
-    // Read a block
-    size_t read = testFile.read(sdBuffer, SD_BUFFER_SIZE);
-    seekChecksum += sdBuffer[0];  // Just check first byte
-  }
-  
-  elapsed = micros() - startTime;
-  testFile.close();
-  
-  float seeksPerMs = (seekCount * 1000.0f) / elapsed;
-  Serial.print(F("  Seeks: "));
-  Serial.print(seekCount);
-  Serial.print(F(" in "));
-  Serial.print(elapsed / 1000.0f, 2);
-  Serial.println(F(" ms"));
-  Serial.print(F("  Speed: "));
-  Serial.print(seeksPerMs, 2);
-  Serial.println(F(" seeks/ms"));
-  Serial.print(F("  Time per seek: "));
-  Serial.print((float)elapsed / seekCount / 1000.0f, 2);
-  Serial.println(F(" ms"));
-  Serial.print(F("  Checksum: 0x"));
-  Serial.println((unsigned long)seekChecksum, HEX);
-  Serial.println();
-  
-  // Benchmark 4: File Operations (Create/Delete)
-  Serial.println(F("Test: File Operations"));
-  
-  const uint32_t fileOpCount = 50;
-  startTime = micros();
-  
-  for (uint32_t i = 0; i < fileOpCount; i++) {
-    // Create file
-    char filename[16];
-    sprintf(filename, "test%lu.tmp", (unsigned long)i);
-    
-    File f = SD.open(filename, FILE_WRITE);
-    if (f) {
-      f.println("Test data");
-      f.close();
-    }
-    
-    // Delete file
-    SD.remove(filename);
-  }
-  
-  elapsed = micros() - startTime;
-  
-  float fileOpsPerMs = (fileOpCount * 2 * 1000.0f) / elapsed;  // *2 for create+delete
-  Serial.print(F("  Operations: "));
-  Serial.print(fileOpCount * 2);
-  Serial.print(F(" ("));
-  Serial.print(fileOpCount);
-  Serial.print(F(" creates + "));
-  Serial.print(fileOpCount);
-  Serial.println(F(" deletes)"));
-  Serial.print(F("  Time: "));
-  Serial.print(elapsed / 1000.0f, 2);
-  Serial.println(F(" ms"));
-  Serial.print(F("  Speed: "));
-  Serial.print(fileOpsPerMs, 2);
-  Serial.println(F(" ops/ms"));
-  Serial.println();
-  
-  // Clean up test file
-  SD.remove(TEST_FILENAME);
-  
-  Serial.println(F("SD card benchmarks complete"));
-}
-#endif  // HAS_SD_CARD
-
 // ==================== SYSTEM INFO ====================
 
 void printSystemInfo() {
@@ -3900,7 +3665,7 @@ void printSystemInfo() {
 #endif
 
 #if defined(ARDUINO_AVR_MULTIDUINO)
-  Serial.println(F("Features: RTC (DS1307), microSD card"));
+  Serial.println(F("Features: RTC (DS1307)"));
 #endif
 
   // RAM Info
@@ -4038,9 +3803,6 @@ void setup() {
   // Multiduino-specific benchmarks
 #ifdef HAS_RTC
   benchmarkRTC();
-#endif
-#ifdef HAS_SD_CARD
-  benchmarkSDCard();
 #endif
 
   // Final summary


### PR DESCRIPTION
### Motivation
- Remove the leftover "microSD card" mention from the Multiduino system information so the reported feature list matches the code after SD support was removed.

### Description
- Change the Multiduino system info string in `UniversalArduinoBenchmark.ino` from `Serial.println(F("Features: RTC (DS1307), microSD card"));` to `Serial.println(F("Features: RTC (DS1307)"));`.

### Testing
- Located the original occurrence with `rg -n "microSD|SD" UniversalArduinoBenchmark.ino` and inspected the nearby lines with `sed -n '3640,3695p'` and `nl -ba UniversalArduinoBenchmark.ino | sed -n '3658,3685p'` to confirm the feature line was updated and no longer references "microSD".

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697aa67ef4b4833181e1bcef3960c6ae)