### PR TITLE
Limit LED matrix to Uno R4 WiFi

### DIFF
--- a/UniversalArduinoBenchmark.ino
+++ b/UniversalArduinoBenchmark.ino
@@ -117,9 +117,7 @@
 #include "Arduino_LED_Matrix.h"
 #elif defined(ARDUINO_UNOR4_MINIMA)
 #define BOARD_NAME "Arduino Uno R4 Minima"
-#define HAS_LED_MATRIX
 #include <EEPROM.h>
-#include "Arduino_LED_Matrix.h"
 #elif defined(ARDUINO_ARCH_RENESAS)
 #define BOARD_NAME "Renesas (Uno R4 family)"
 #include <EEPROM.h>


### PR DESCRIPTION
### Motivation
- Ensure LED matrix benchmarks and related includes/flags only compile for `ARDUINO_UNOR4_WIFI`, since the Minima model does not have the LED matrix.

### Description
- Removed `#define HAS_LED_MATRIX` and `#include "Arduino_LED_Matrix.h"` from the `ARDUINO_UNOR4_MINIMA` branch in `UniversalArduinoBenchmark.ino` so matrix code is enabled only when the WiFi branch defines `HAS_LED_MATRIX`.

### Testing
- Ran automated file inspections (`rg` and `nl`/`sed`) to confirm `HAS_LED_MATRIX` is now defined only under `ARDUINO_UNOR4_WIFI` and the Minima branch no longer includes `Arduino_LED_Matrix.h`; no build or unit tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b3680e3688331a137da9d1d3ae8bf)