### PR TITLE
Adjust WiFi MAC address byte iteration order

### DIFF
--- a/UniversalArduinoBenchmark.ino
+++ b/UniversalArduinoBenchmark.ino
@@ -1813,10 +1813,10 @@ void benchmarkWiFi() {
   SERIAL_OUT.print(F_STR("MAC Address: "));
   byte mac[6];
   WiFi.macAddress(mac);
-  for (int i = 5; i >= 0; i--) {
+  for (int i = 0; i <= 5; i++) {
     if (mac[i] < 16) SERIAL_OUT.print("0");
     SERIAL_OUT.print(mac[i], HEX);
-    if (i > 0) SERIAL_OUT.print(":");
+    if (i < 5) SERIAL_OUT.print(":");
   }
   SERIAL_OUT.println();
 #else
@@ -1824,10 +1824,10 @@ void benchmarkWiFi() {
   byte mac[6];
   WiFi.macAddress(mac);
   SERIAL_OUT.print(F_STR("MAC Address: "));
-  for (int i = 5; i >= 0; i--) {
+  for (int i = 0; i <= 5; i++) {
     if (mac[i] < 16) SERIAL_OUT.print("0");
     SERIAL_OUT.print(mac[i], HEX);
-    if (i > 0) SERIAL_OUT.print(":");
+    if (i < 5) SERIAL_OUT.print(":");
   }
   SERIAL_OUT.println();
 #endif


### PR DESCRIPTION
### Motivation
- Ensure the printed MAC address bytes are output in ascending order (0..5) with leading-zero padding while preserving hex formatting and colon separators.

### Description
- In `benchmarkWiFi()` updated the MAC printing loops for the `ARDUINO_UNOR4_WIFI` and WiFiNINA/WiFi101 branches to use `for (int i = 0; i <= 5; i++)` and changed the separator check to `if (i < 5)` while keeping `SERIAL_OUT.print(mac[i], HEX)` and the leading-zero logic.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b3753aab8833190d25c8e57b227ea)