### PR TITLE
Label STM32U5 non-Zephyr RNG as pseudo RNG

### DIFF
--- a/UniversalArduinoBenchmark.ino
+++ b/UniversalArduinoBenchmark.ino
@@ -2903,7 +2903,11 @@ void benchmarkSerialBaudRates() {
 
 #if defined(ESP32) || defined(BOARD_STM32U5)
 void benchmarkHardwareRNG() {
+#if defined(ESP32) || (defined(BOARD_STM32U5) && defined(__ZEPHYR__))
   printHeader("CRYPTO: Hardware RNG");
+#else
+  printHeader("CRYPTO: Pseudo RNG");
+#endif
 
 #if defined(ESP32)
   SERIAL_OUT.println(F_STR("Using ESP32 hardware RNG"));
@@ -2911,7 +2915,7 @@ void benchmarkHardwareRNG() {
   #if defined(__ZEPHYR__)
   SERIAL_OUT.println(F_STR("Using STM32U585 hardware RNG (Zephyr)"));
   #else
-  SERIAL_OUT.println(F_STR("Using STM32U585 RNG"));
+  SERIAL_OUT.println(F_STR("Using STM32U585 pseudo RNG (Arduino random)"));
   #endif
 #endif
 
@@ -2932,7 +2936,11 @@ void benchmarkHardwareRNG() {
   SERIAL_OUT.print(F_STR("Checksum: "));
   SERIAL_OUT.println(rngSum);
 
+#if defined(ESP32) || (defined(BOARD_STM32U5) && defined(__ZEPHYR__))
   SERIAL_OUT.print(F_STR("Hardware RNG (1000 values): "));
+#else
+  SERIAL_OUT.print(F_STR("Pseudo RNG (1000 values): "));
+#endif
   SERIAL_OUT.print(rngTime);
   SERIAL_OUT.print(F_STR(" μs ("));
   SERIAL_OUT.print(1000.0f / rngTime * 1000, 2);


### PR DESCRIPTION
### Motivation
- Align benchmark output with the actual implementation because the STM32U5 branch falls back to Arduino `random()` when Zephyr is not available, so it should not be described as a true hardware RNG.

### Description
- Update `benchmarkHardwareRNG()` to print the header as "CRYPTO: Pseudo RNG" for `BOARD_STM32U5` when `__ZEPHYR__` is not defined, change the per-branch log to `Using STM32U585 pseudo RNG (Arduino random)`, and change the timing label to "Pseudo RNG (1000 values):" for that fallback path while leaving the ESP32 and Zephyr paths unchanged.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b381929e08331bce7248763bf9a94)