### PR TITLE
Support Arduino Giga R1 WiFi build: include WiFi and guard F_CPU

### DIFF
--- a/UniversalArduinoBenchmark.ino
+++ b/UniversalArduinoBenchmark.ino
@@ -197,6 +197,7 @@
 #define HAS_BLE
 #define HAS_DUAL_CORE
 #define BOARD_STM32H7
+#include <WiFi.h>
 
 // Arduino Mega + WiFi
 #elif defined(ARDUINO_AVR_MEGA2560)
@@ -3667,8 +3668,12 @@ void printSystemInfo() {
   SERIAL_OUT.print(F_STR("MCU: STM32H7 (ARM Cortex-M7)"));
   SERIAL_OUT.println();
   SERIAL_OUT.print(F_STR("CPU Frequency: "));
+#if defined(F_CPU)
   SERIAL_OUT.print(F_CPU / 1000000);
   SERIAL_OUT.println(F_STR(" MHz"));
+#else
+  SERIAL_OUT.println(F_STR("Unknown"));
+#endif
 #ifdef HAS_DUAL_CORE
   SERIAL_OUT.println(F_STR("Cores: Dual Core (M7 + M4)"));
 #endif


### PR DESCRIPTION
### Motivation
- Fix compile errors when targeting `ARDUINO_GIGA` where `WiFi` symbols were missing and `F_CPU` may be undefined for the STM32H7 board output.

### Description
- Add `#include <WiFi.h>` inside the `#elif defined(ARDUINO_GIGA)` board block so `WiFi` symbols resolve for Arduino Giga R1 WiFi builds.
- Surround the STM32H7 CPU frequency printing with `#if defined(F_CPU)`/`#else` and print `Unknown` when `F_CPU` is not defined to avoid compile failures.

### Testing
- No automated tests were run for this change; the patch has been applied and committed for downstream compilation validation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b3da7e4208331a3023c584bdd6879)