### PR TITLE
Define NOT_AN_INTERRUPT fallback for cores missing it

### DIFF
--- a/UniversalArduinoBenchmark.ino
+++ b/UniversalArduinoBenchmark.ino
@@ -26,6 +26,10 @@
 
 #include <limits.h>
 
+#ifndef NOT_AN_INTERRUPT
+#define NOT_AN_INTERRUPT -1
+#endif
+
 // ==================== BOARD DETECTION ====================
 
 // ESP32 Family (all variants)


### PR DESCRIPTION
### Motivation
- Provide a fallback definition for `NOT_AN_INTERRUPT` to prevent a compile-time error on cores (e.g. Uno R4 WiFi) that do not define the macro so the interrupt-latency benchmark can be evaluated.

### Description
- Add a preprocessor guard near the top of `UniversalArduinoBenchmark.ino` that defines `NOT_AN_INTERRUPT` as `-1` when it is not already defined (`#ifndef NOT_AN_INTERRUPT` / `#define NOT_AN_INTERRUPT -1`).

### Testing
- No automated tests were run after this change; the patch is a minimal, compile-time-only fallback to avoid the `'NOT_AN_INTERRUPT' was not declared` error. Please compile for the target board to verify success.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697c217f6ab483319f7dc9e3083c0c3c)