### PR TITLE
Use ESP32 LEDC for PWM benchmark to avoid slow analogWrite path

### DIFF
--- a/UniversalArduinoBenchmark.ino
+++ b/UniversalArduinoBenchmark.ino
@@ -4443,16 +4443,40 @@ void benchmarkPWM() {
   SERIAL_OUT.print(F_STR("Testing PWM on pin "));
   SERIAL_OUT.println(pwmPin);
 
-  // analogWrite speed benchmark
+  // PWM update benchmark
+#if defined(ESP32)
+  const int pwmFreq = 5000;
+  const int pwmResolution = 8;
+#if defined(ESP_ARDUINO_VERSION_MAJOR) && ESP_ARDUINO_VERSION_MAJOR >= 3
+  ledcAttach(pwmPin, pwmFreq, pwmResolution);
+#else
+  const int pwmChannel = 0;
+  ledcSetup(pwmChannel, pwmFreq, pwmResolution);
+  ledcAttachPin(pwmPin, pwmChannel);
+#endif
+#endif
+
   volatile uint8_t duty = 0;
   startBenchmark();
   for (int i = 0; i < 10000; i++) {
+#if defined(ESP32)
+  #if defined(ESP_ARDUINO_VERSION_MAJOR) && ESP_ARDUINO_VERSION_MAJOR >= 3
+    ledcWrite(pwmPin, duty);
+  #else
+    ledcWrite(pwmChannel, duty);
+  #endif
+#else
     analogWrite(pwmPin, duty);
+#endif
     duty++;
   }
   unsigned long pwmTime = endBenchmark();
 
+#if defined(ESP32)
+  SERIAL_OUT.print(F_STR("LEDC duty update (10000 ops): "));
+#else
   SERIAL_OUT.print(F_STR("analogWrite() (10000 ops): "));
+#endif
   SERIAL_OUT.print(pwmTime);
   SERIAL_OUT.print(F_STR(" us ("));
   SERIAL_OUT.print(10000.0 / pwmTime * 1000);
@@ -4462,7 +4486,15 @@ void benchmarkPWM() {
   startBenchmark();
   for (int cycle = 0; cycle < 100; cycle++) {
     for (int val = 0; val < 256; val++) {
+#if defined(ESP32)
+  #if defined(ESP_ARDUINO_VERSION_MAJOR) && ESP_ARDUINO_VERSION_MAJOR >= 3
+      ledcWrite(pwmPin, val);
+  #else
+      ledcWrite(pwmChannel, val);
+  #endif
+#else
       analogWrite(pwmPin, val);
+#endif
     }
   }
   unsigned long rampTime = endBenchmark();
@@ -4478,7 +4510,15 @@ void benchmarkPWM() {
   SERIAL_OUT.print(rampTime / 25600.0, 3);
   SERIAL_OUT.println(F_STR(" us"));
 
+#if defined(ESP32)
+  #if defined(ESP_ARDUINO_VERSION_MAJOR) && ESP_ARDUINO_VERSION_MAJOR >= 3
+  ledcWrite(pwmPin, 0);
+  #else
+  ledcWrite(pwmChannel, 0);
+  #endif
+#else
   analogWrite(pwmPin, 0);
+#endif
 }
 
 // Interrupt Latency Benchmark


### PR DESCRIPTION
### Motivation
- The ESP32 PWM benchmark was exercising a generic `analogWrite()` path which can invoke expensive LEDC reconfiguration and attachment per call, producing misleadingly slow results.
- The change aims to measure true LEDC update performance and avoid the compatibility-layer overhead that caused ~2 ms per update on ESP32.

### Description
- Update `UniversalArduinoBenchmark.ino` to configure the ESP32 LEDC once before the benchmark using `ledcSetup`/`ledcAttachPin` or `ledcAttach` depending on core version. 
- Replace per-iteration `analogWrite()` calls with `ledcWrite()` on ESP32 for both the 10k update loop and the 100-cycle ramp. 
- Adjust printed labels to distinguish `LEDC duty update` output on ESP32 versus `analogWrite()` on other platforms. 
- Ensure the final duty is set to zero via `ledcWrite()` on ESP32 and `analogWrite()` elsewhere.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697c2589f6b8833192af70c5f2ca1d39)