### PR TITLE
Fix missing Serial output on Arduino Yun and other native USB boards

### DIFF
--- a/UniversalArduinoBenchmark.ino
+++ b/UniversalArduinoBenchmark.ino
@@ -5328,6 +5328,21 @@ void setup() {
   delay(3000);  // ESP32 needs extra time for serial initialization
 #else
   SERIAL_OUT.begin(SERIAL_BAUD);
+  // ATmega32U4 boards (Yun, Leonardo, Micro) and other native USB boards
+  // have a virtual USB CDC serial port that doesn't exist until the host
+  // USB connection is negotiated. Without this wait, all Serial output is
+  // lost because the port isn't ready yet. A fixed delay() is insufficient
+  // because USB enumeration timing varies. The while(!Serial) loop blocks
+  // until the port is actually connected. Timeout after 10s so the sketch
+  // can still run standalone (without Serial Monitor) if needed.
+#if defined(USBCON)
+  {
+    unsigned long waitStart = millis();
+    while (!SERIAL_OUT && (millis() - waitStart < 10000)) {
+      delay(10);
+    }
+  }
+#endif
   delay(2000);  // Wait for serial connection
 #endif
 


### PR DESCRIPTION
ATmega32U4-based boards (Yun, Leonardo, Micro) and other native USB boards use a virtual USB CDC serial port that doesn't exist until the host USB connection is negotiated. The previous code only used a fixed delay(2000) which is insufficient — USB enumeration timing varies, and if Serial Monitor is opened after the sketch starts, all output is lost.

Add while(!Serial) gated on USBCON with a 10-second timeout so the sketch waits for the USB serial port to actually connect before printing. The timeout ensures the sketch can still proceed if running standalone.

https://claude.ai/code/session_01MKyZ5djMv1MPCu6Two9Jey