### PR TITLE
Move header print before Bridge.begin() to fix silent hang on Yun

### DIFF
--- a/UniversalArduinoBenchmark.ino
+++ b/UniversalArduinoBenchmark.ino
@@ -5346,10 +5346,6 @@ void setup() {
   delay(2000);  // Wait for serial connection
 #endif
 
-#if defined(HAS_YUN_BRIDGE)
-  Bridge.begin();  // Initialize Bridge between ATmega32U4 and Linux
-#endif
-
   calibrateBenchmarkTime();
 
   SERIAL_OUT.println();
@@ -5358,6 +5354,14 @@ void setup() {
   SERIAL_OUT.println(F_STR("  UNIVERSAL ARDUINO BENCHMARK SUITE"));
   printDivider();
   SERIAL_OUT.println();
+
+#if defined(HAS_YUN_BRIDGE)
+  SERIAL_OUT.println(F("Initializing Yun Bridge (may take ~60s after power-on)..."));
+  SERIAL_OUT.flush();  // Force bytes out before Bridge.begin() blocks
+  Bridge.begin();
+  SERIAL_OUT.println(F("Bridge ready."));
+  SERIAL_OUT.println();
+#endif
 
   // System info
   printSystemInfo();


### PR DESCRIPTION
Bridge.begin() blocks indefinitely until the AR9331 Linux side responds (can take 60+ seconds after power-on). Previously it was called before ANY Serial output, so if Bridge hung, the user saw nothing at all — not even the header — making it look like Serial was broken.

Reorder setup() so the banner prints immediately after Serial is ready, then show a "Initializing Yun Bridge..." status with Serial.flush() before Bridge.begin() blocks. This way the user always sees output and knows to wait for Bridge rather than thinking Serial is dead.

https://claude.ai/code/session_01MKyZ5djMv1MPCu6Two9Jey