### PR TITLE
Remove per-iteration output from delay timing benchmarks

### DIFF
--- a/UniversalArduinoBenchmark.ino
+++ b/UniversalArduinoBenchmark.ino
@@ -2726,8 +2726,6 @@ void benchmarkDelayTiming() {
   printHeader("TIMING: delay() and delayMicroseconds() Accuracy");
 
   // --- delay() accuracy: test delay(0) .. delay(50) ---
-  SERIAL_OUT.println(F_STR("delay(ms)  actual(ms)  error(ms)"));
-
   long delayErrorSum = 0;
   long delayMaxError = 0;
   const int delaySteps = 51;  // 0..50
@@ -2736,45 +2734,29 @@ void benchmarkDelayTiming() {
     unsigned long t1 = micros();
     delay(ms);
     unsigned long t2 = micros();
-    long actual = (long)(t2 - t1);                      // in microseconds
-    long expected = (long)ms * 1000L;                    // in microseconds
-    long err = actual - expected;                        // signed error
-
-    long absErr = err < 0 ? -err : err;
+    long actual = (long)(t2 - t1);
+    long expected = (long)ms * 1000L;
+    long absErr = actual - expected;
+    if (absErr < 0) absErr = -absErr;
     delayErrorSum += absErr;
     if (absErr > delayMaxError) delayMaxError = absErr;
-
-    SERIAL_OUT.print(F_STR("  "));
-    if (ms < 10) SERIAL_OUT.print(' ');
-    SERIAL_OUT.print(ms);
-    SERIAL_OUT.print(F_STR("        "));
-    // Print actual in ms with 3 decimals
-    SERIAL_OUT.print(actual / 1000.0f, 3);
-    SERIAL_OUT.print(F_STR("     "));
-    // Print signed error in ms with 3 decimals
-    if (err >= 0) SERIAL_OUT.print('+');
-    SERIAL_OUT.println(err / 1000.0f, 3);
 
 #if defined(ESP32) || defined(ESP8266) || defined(ARDUINO_ARCH_RP2040)
     yield();
 #endif
   }
 
-  float delayAvgError = delayErrorSum / (float)delaySteps / 1000.0f;  // in ms
+  float delayAvgError = delayErrorSum / (float)delaySteps / 1000.0f;
   float delayMaxErrorMs = delayMaxError / 1000.0f;
 
-  SERIAL_OUT.println();
-  SERIAL_OUT.print(F_STR("delay() avg absolute error: "));
+  SERIAL_OUT.print(F_STR("delay(0..50) avg absolute error: "));
   SERIAL_OUT.print(delayAvgError, 3);
   SERIAL_OUT.println(F_STR(" ms"));
-  SERIAL_OUT.print(F_STR("delay() max absolute error: "));
+  SERIAL_OUT.print(F_STR("delay(0..50) max absolute error: "));
   SERIAL_OUT.print(delayMaxErrorMs, 3);
   SERIAL_OUT.println(F_STR(" ms"));
 
   // --- delayMicroseconds() accuracy: test 0..50 us ---
-  SERIAL_OUT.println();
-  SERIAL_OUT.println(F_STR("delayMicroseconds(us)  actual(us)  error(us)"));
-
   long dusErrorSum = 0;
   long dusMaxError = 0;
   const int dusSteps = 51;  // 0..50
@@ -2799,22 +2781,10 @@ void benchmarkDelayTiming() {
       measurements[j + 1] = key;
     }
     long actual = measurements[2];  // median
-    long expected = (long)us;
-    long err = actual - expected;
-
-    long absErr = err < 0 ? -err : err;
+    long absErr = actual - (long)us;
+    if (absErr < 0) absErr = -absErr;
     dusErrorSum += absErr;
     if (absErr > dusMaxError) dusMaxError = absErr;
-
-    SERIAL_OUT.print(F_STR("  "));
-    if (us < 10) SERIAL_OUT.print(' ');
-    SERIAL_OUT.print(us);
-    SERIAL_OUT.print(F_STR("                    "));
-    if (actual < 10) SERIAL_OUT.print(' ');
-    SERIAL_OUT.print(actual);
-    SERIAL_OUT.print(F_STR("          "));
-    if (err >= 0) SERIAL_OUT.print('+');
-    SERIAL_OUT.println(err);
 
 #if defined(ESP32) || defined(ESP8266) || defined(ARDUINO_ARCH_RP2040)
     yield();
@@ -2823,11 +2793,10 @@ void benchmarkDelayTiming() {
 
   float dusAvgError = dusErrorSum / (float)dusSteps;
 
-  SERIAL_OUT.println();
-  SERIAL_OUT.print(F_STR("delayMicroseconds() avg absolute error: "));
+  SERIAL_OUT.print(F_STR("delayMicroseconds(0..50) avg absolute error: "));
   SERIAL_OUT.print(dusAvgError, 1);
   SERIAL_OUT.println(F_STR(" us"));
-  SERIAL_OUT.print(F_STR("delayMicroseconds() max absolute error: "));
+  SERIAL_OUT.print(F_STR("delayMicroseconds(0..50) max absolute error: "));
   SERIAL_OUT.print(dusMaxError);
   SERIAL_OUT.println(F_STR(" us"));
 }


### PR DESCRIPTION
Only print the final summary (avg/max absolute error) for both delay() and delayMicroseconds() tests instead of one line per iteration.

https://claude.ai/code/session_018WBrU3z8ZiEZky3rTc2NPC