### PR TITLE
Move extern \"C\" sbrk declaration to file scope to fix compile error

### DIFF
--- a/UniversalArduinoBenchmark.ino
+++ b/UniversalArduinoBenchmark.ino
@@ -2945,6 +2945,13 @@ int probeStackLimit(int depth, uintptr_t stackBase, size_t stackBudget) {
   return probeStackLimit(depth + 1, stackBase, stackBudget) + (buffer[0] & 1);
 }
 
+// Forward-declare sbrk at file scope (extern "C" is not allowed inside
+// a function body in C++).  Guarded so it only appears on platforms that
+// actually provide it via newlib / picolibc.
+#if !defined(ESP32) && !defined(ESP8266) && !defined(__AVR__)
+extern "C" char *sbrk(int i);
+#endif
+
 // Platform-specific: how many bytes of stack can we still use?
 // Called from benchmarkStackDepth() with &stackBase on the caller's frame.
 static size_t getStackBudget(uintptr_t callerFrame) {
@@ -2967,15 +2974,11 @@ static size_t getStackBudget(uintptr_t callerFrame) {
   uintptr_t heapTop = (__brkval == 0) ? (uintptr_t)&__heap_start
                                       : (uintptr_t)__brkval;
   return (callerFrame > heapTop) ? (size_t)(callerFrame - heapTop) : 256;
-#elif defined(ARDUINO_SAM_DUE)
-  extern "C" char *sbrk(int i);
-  uintptr_t heapTop = (uintptr_t)sbrk(0);
-  return (callerFrame > heapTop) ? (size_t)(callerFrame - heapTop) : 256;
-#elif defined(ARDUINO_ARCH_RP2040) || defined(BOARD_STM32U5)        \
-   || defined(BOARD_SAMD) || defined(BOARD_NRF52)                   \
+#elif defined(ARDUINO_SAM_DUE) || defined(ARDUINO_ARCH_RP2040)      \
+   || defined(BOARD_STM32U5) || defined(BOARD_SAMD)                 \
+   || defined(BOARD_NRF52)                                          \
    || defined(ARDUINO_UNOR4_WIFI) || defined(ARDUINO_UNOR4_MINIMA)
-  // ARM Cortex boards with newlib — sbrk(0) gives the heap break
-  extern "C" char *sbrk(int i);
+  // ARM Cortex boards with newlib -- sbrk(0) gives the heap break
   uintptr_t heapTop = (uintptr_t)sbrk(0);
   return (callerFrame > heapTop) ? (size_t)(callerFrame - heapTop) : 256;
 #else


### PR DESCRIPTION
extern \"C\" is not allowed inside a function body in C++. Move the sbrk forward declaration before getStackBudget() with a preprocessor guard so it only appears on platforms that provide it (not ESP32, ESP8266, or AVR). Collapse the Due and ARM Cortex branches into a single #elif since they share the same sbrk-based logic.

https://claude.ai/code/session_01SwkZBCDcRYUsch6CaazQZT