### PR TITLE
Add real sleep-mode tests for all boards + clean ISR latency measurement

### DIFF
--- a/Part1_CoreBenchmarks/Part1_CoreBenchmarks.ino
+++ b/Part1_CoreBenchmarks/Part1_CoreBenchmarks.ino
@@ -1939,60 +1939,152 @@ void benchmarkInterruptLatency() {
   attachInterrupt(interruptNumber, latencyISR, RISING);
 #endif
 
-  // Measure interrupt latency
-  unsigned long totalLatency = 0;
-  int successfulMeasurements = 0;
+  // ====== Pass 1: digitalWrite trigger (includes its overhead) ======
+  unsigned long totalLatencyDW = 0;
+  int successDW = 0;
   const int iterations = 100;
 
   for (int i = 0; i < iterations; i++) {
     isrFired = false;
 
-    // Trigger the interrupt
     isrStartTime = micros();
 #if defined(__AVR__)
-    digitalWrite(triggerPin, LOW);  // FALLING edge for AVR
+    digitalWrite(triggerPin, LOW);   // FALLING edge
 #else
-    digitalWrite(triggerPin, HIGH);  // RISING edge for others
+    digitalWrite(triggerPin, HIGH);  // RISING edge
 #endif
 
-    // Wait for ISR (with timeout)
-    unsigned long timeout = micros() + 1000;  // 1ms timeout
-    while (!isrFired && micros() < timeout) {
-      // Spin
-    }
+    unsigned long timeout = micros() + 1000;
+    while (!isrFired && micros() < timeout) {}
 
 #if defined(__AVR__)
-    digitalWrite(triggerPin, HIGH);  // Reset for next FALLING edge
+    digitalWrite(triggerPin, HIGH);  // Reset
 #else
-    digitalWrite(triggerPin, LOW);   // Reset for next RISING edge
+    digitalWrite(triggerPin, LOW);
 #endif
 
     if (isrFired) {
-      unsigned long latency = isrEndTime - isrStartTime;
-      totalLatency += latency;
-      successfulMeasurements++;
+      totalLatencyDW += isrEndTime - isrStartTime;
+      successDW++;
     }
-
-    delayMicroseconds(100);  // Small delay between tests
+    delayMicroseconds(100);
   }
 
   detachInterrupt(interruptNumber);
 
-  if (successfulMeasurements > 0) {
-    float avgLatency = (float)totalLatency / successfulMeasurements;
+  // ====== Pass 2: direct port/register trigger (pure ISR entry) ======
+  // Re-attach for pass 2
+#if defined(__AVR__)
+  attachInterrupt(interruptNumber, latencyISR, FALLING);
+#else
+  attachInterrupt(interruptNumber, latencyISR, RISING);
+#endif
 
-    SERIAL_OUT.print(F_STR("Successful measurements: "));
-    SERIAL_OUT.print(successfulMeasurements);
+  unsigned long totalLatencyDirect = 0;
+  int successDirect = 0;
+
+  // Pre-compute register pointers / masks for the trigger pin
+#if defined(__AVR__)
+  volatile uint8_t *trigPort = portOutputRegister(digitalPinToPort(triggerPin));
+  uint8_t trigMask = digitalPinToBitMask(triggerPin);
+  // AVR FALLING: clear the bit to trigger
+  #define DIRECT_TRIGGER()  (*trigPort &= ~trigMask)
+  #define DIRECT_RESET()    (*trigPort |=  trigMask)
+#elif defined(ESP32)
+  // ESP32 RISING: set the GPIO
+  #if defined(CONFIG_IDF_TARGET_ESP32C6) || defined(CONFIG_IDF_TARGET_ESP32C5) \
+   || defined(CONFIG_IDF_TARGET_ESP32H2) || defined(CONFIG_IDF_TARGET_ESP32C3)
+    #define DIRECT_TRIGGER() do { GPIO.out_w1ts.val = 1u << triggerPin; } while(0)
+    #define DIRECT_RESET()   do { GPIO.out_w1tc.val = 1u << triggerPin; } while(0)
+  #elif ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 0, 0)
+    #define DIRECT_TRIGGER() do { if (triggerPin < 32) GPIO.out_w1ts = 1u << triggerPin; \
+                                  else GPIO.out1_w1ts.data = 1u << (triggerPin - 32); } while(0)
+    #define DIRECT_RESET()   do { if (triggerPin < 32) GPIO.out_w1tc = 1u << triggerPin; \
+                                  else GPIO.out1_w1tc.data = 1u << (triggerPin - 32); } while(0)
+  #else
+    #define DIRECT_TRIGGER() digitalWrite(triggerPin, HIGH)
+    #define DIRECT_RESET()   digitalWrite(triggerPin, LOW)
+  #endif
+#elif defined(ARDUINO_ARCH_RP2040)
+  // RP2040 RISING: SIO direct set/clear
+  #define DIRECT_TRIGGER() do { sio_hw->gpio_set = 1ul << triggerPin; } while(0)
+  #define DIRECT_RESET()   do { sio_hw->gpio_clr = 1ul << triggerPin; } while(0)
+#else
+  // Fallback for boards without known direct-register access
+  #if defined(__AVR__)
+    // already handled above
+  #else
+    #define DIRECT_TRIGGER() digitalWrite(triggerPin, HIGH)
+    #define DIRECT_RESET()   digitalWrite(triggerPin, LOW)
+  #endif
+#endif
+
+  for (int i = 0; i < iterations; i++) {
+    isrFired = false;
+
+    isrStartTime = micros();
+    DIRECT_TRIGGER();
+
+    unsigned long timeout = micros() + 1000;
+    while (!isrFired && micros() < timeout) {}
+
+    DIRECT_RESET();
+
+    if (isrFired) {
+      totalLatencyDirect += isrEndTime - isrStartTime;
+      successDirect++;
+    }
+    delayMicroseconds(100);
+  }
+
+  detachInterrupt(interruptNumber);
+
+  // Clean up macros
+#undef DIRECT_TRIGGER
+#undef DIRECT_RESET
+
+  // ====== Report ======
+  SERIAL_OUT.println();
+
+  if (successDW > 0) {
+    float avgDW = (float)totalLatencyDW / successDW;
+    SERIAL_OUT.print(F_STR("Pass 1 – digitalWrite trigger ("));
+    SERIAL_OUT.print(successDW);
     SERIAL_OUT.print(F_STR("/"));
-    SERIAL_OUT.println(iterations);
-
-    SERIAL_OUT.print(F_STR("Average interrupt latency: "));
-    SERIAL_OUT.print(avgLatency, 2);
-    SERIAL_OUT.println(F_STR(" us"));
-
-    SERIAL_OUT.println();
-    SERIAL_OUT.println(F_STR("Note: Includes digitalWrite + ISR entry overhead"));
+    SERIAL_OUT.print(iterations);
+    SERIAL_OUT.println(F_STR("):"));
+    SERIAL_OUT.print(F_STR("  Avg latency: "));
+    SERIAL_OUT.print(avgDW, 2);
+    SERIAL_OUT.println(F_STR(" us (includes digitalWrite overhead)"));
   } else {
+    SERIAL_OUT.println(F_STR("Pass 1 – digitalWrite trigger: FAILED"));
+  }
+
+  if (successDirect > 0) {
+    float avgDirect = (float)totalLatencyDirect / successDirect;
+    SERIAL_OUT.print(F_STR("Pass 2 – direct port trigger ("));
+    SERIAL_OUT.print(successDirect);
+    SERIAL_OUT.print(F_STR("/"));
+    SERIAL_OUT.print(iterations);
+    SERIAL_OUT.println(F_STR("):"));
+    SERIAL_OUT.print(F_STR("  Avg latency: "));
+    SERIAL_OUT.print(avgDirect, 2);
+    SERIAL_OUT.println(F_STR(" us (pure ISR entry latency)"));
+  } else {
+    SERIAL_OUT.println(F_STR("Pass 2 – direct port trigger: FAILED"));
+  }
+
+  if (successDW > 0 && successDirect > 0) {
+    float avgDW = (float)totalLatencyDW / successDW;
+    float avgDirect = (float)totalLatencyDirect / successDirect;
+    float overhead = avgDW - avgDirect;
+    SERIAL_OUT.println();
+    SERIAL_OUT.print(F_STR("digitalWrite overhead: ~"));
+    SERIAL_OUT.print(overhead, 2);
+    SERIAL_OUT.println(F_STR(" us"));
+  }
+
+  if (successDW == 0 && successDirect == 0) {
     SERIAL_OUT.println(F_STR("Interrupt measurement failed"));
     SERIAL_OUT.println(F_STR("(Pin may not support interrupts)"));
   }

--- a/Part2_PlatformBenchmarks/Part2_PlatformBenchmarks.ino
+++ b/Part2_PlatformBenchmarks/Part2_PlatformBenchmarks.ino
@@ -444,6 +444,22 @@
 #include "stm32h7xx_ll_adc.h"
 #endif
 
+#if defined(BOARD_SAMD)
+#include <samd.h>  // PM->SLEEP.reg, SCB->SCR
+#endif
+
+#if defined(BOARD_NRF52)
+#include <nrf.h>   // NRF_POWER, __WFE
+#endif
+
+#if defined(ESP8266)
+#include <user_interface.h>  // wifi_set_sleep_type, light_sleep
+#endif
+
+#if defined(TEENSYDUINO) && defined(__IMXRT1062__)
+#include <imxrt.h>  // Teensy 4.x ARM registers
+#endif
+
 
 // ==================== SERIAL OUTPUT ABSTRACTION ====================
 // Uno Q uses Monitor instead of Serial for output
@@ -4022,70 +4038,452 @@ void benchmarkWatchdog() {
 void benchmarkSleepModes() {
   printHeader("POWER: SLEEP MODE TIMING");
 
+  // ----------------------------------------------------------------
+  // Helper lambdas would be nice but we keep plain C for AVR compat.
+  // Strategy: enter the lightest sleep that preserves micros() tick
+  // (idle / WFI), measure wake-up time, then repeat for a batch.
+  // Deep-sleep / power-down modes reset the MCU so we skip those.
+  // ----------------------------------------------------------------
+
 #if defined(ESP32)
   // Already covered in benchmarkESP32Sleep()
   SERIAL_OUT.println(F_STR("See ESP32 Light Sleep benchmark above"));
 
-#elif defined(ARDUINO_ARCH_RP2040)
-  SERIAL_OUT.println(F_STR("RP2040 Sleep Modes:"));
-  SERIAL_OUT.println(F_STR("  DORMANT: Deep sleep, wake on GPIO/RTC"));
-  SERIAL_OUT.println(F_STR("  SLEEP: WFI/WFE, wake on interrupt"));
+#elif defined(ESP8266)
+  // ESP8266 light-sleep (modem sleep keeps CPU, light sleep halts it)
+  // Timer1 generates the wake interrupt that keeps millis()/micros() alive.
+  SERIAL_OUT.println(F_STR("ESP8266 Light Sleep (timer wake):"));
   SERIAL_OUT.println();
 
-  // Measure __wfi timing
-  SERIAL_OUT.println(F_STR("Testing WFI (Wait For Interrupt):"));
+  // Single wake latency
+  unsigned long esp8266Start = micros();
+  delay(1);  // enters idle/modem-sleep automatically via yield()
+  unsigned long esp8266Wake = micros() - esp8266Start;
 
-  // Set up a timer to wake us
-  unsigned long wakeTime = 0;
-  unsigned long sleepStart = 0;
+  SERIAL_OUT.print(F_STR("  Idle-yield wake: "));
+  SERIAL_OUT.print(esp8266Wake);
+  SERIAL_OUT.println(F_STR(" us (target 1000 us)"));
 
-  // Use systick interrupt to wake (happens every 1ms)
-  sleepStart = micros();
-  __wfi();
-  wakeTime = micros() - sleepStart;
+  // Batch WFI via inline asm – available on Xtensa LX106
+  startBenchmark();
+  for (int i = 0; i < 100; i++) {
+    asm volatile("waiti 0");   // wait-for-interrupt, level 0
+  }
+  unsigned long esp8266WfiTime = endBenchmark();
 
-  SERIAL_OUT.print(F_STR("  WFI wake time: "));
-  SERIAL_OUT.print(wakeTime);
+  SERIAL_OUT.print(F_STR("  100x waiti 0: "));
+  SERIAL_OUT.print(esp8266WfiTime);
   SERIAL_OUT.println(F_STR(" us"));
 
-  // Multiple WFI cycles
+#elif defined(ARDUINO_ARCH_RP2040)
+  SERIAL_OUT.println(F_STR("RP2040 Sleep (WFI / WFE):"));
+  SERIAL_OUT.println();
+
+  // --- WFI (Wait For Interrupt) - wakes on SysTick every 1 ms ---
+  unsigned long wfiSingle = 0;
+  {
+    unsigned long t = micros();
+    __wfi();
+    wfiSingle = micros() - t;
+  }
+  SERIAL_OUT.print(F_STR("  WFI single wake: "));
+  SERIAL_OUT.print(wfiSingle);
+  SERIAL_OUT.println(F_STR(" us"));
+
   startBenchmark();
   for (int i = 0; i < 100; i++) {
     __wfi();
   }
-  unsigned long wfiTime = endBenchmark();
+  unsigned long wfiTime100 = endBenchmark();
+  SERIAL_OUT.print(F_STR("  100x WFI: "));
+  SERIAL_OUT.print(wfiTime100);
+  SERIAL_OUT.println(F_STR(" us"));
 
-  SERIAL_OUT.print(F_STR("  100x WFI cycles: "));
-  SERIAL_OUT.print(wfiTime);
+  // --- WFE (Wait For Event) - lighter, wakes on any pending event ---
+  unsigned long wfeSingle = 0;
+  {
+    __sev();  // set event flag so first WFE clears it, second actually sleeps
+    __wfe();  // clear event flag
+    unsigned long t = micros();
+    __wfe();  // real sleep until next event/interrupt
+    wfeSingle = micros() - t;
+  }
+  SERIAL_OUT.print(F_STR("  WFE single wake: "));
+  SERIAL_OUT.print(wfeSingle);
+  SERIAL_OUT.println(F_STR(" us"));
+
+  startBenchmark();
+  for (int i = 0; i < 100; i++) {
+    __sev();
+    __wfe();
+    __wfe();
+  }
+  unsigned long wfeTime100 = endBenchmark();
+  SERIAL_OUT.print(F_STR("  100x WFE: "));
+  SERIAL_OUT.print(wfeTime100);
   SERIAL_OUT.println(F_STR(" us"));
 
 #elif defined(ARDUINO_UNOR4_WIFI) || defined(ARDUINO_UNOR4_MINIMA)
-  SERIAL_OUT.println(F_STR("Renesas RA4M1 Low Power Modes:"));
-  SERIAL_OUT.println(F_STR("  Sleep: CPU stopped, peripherals active"));
-  SERIAL_OUT.println(F_STR("  Deep Sleep: Most peripherals stopped"));
-  SERIAL_OUT.println(F_STR("  Software Standby: Lowest power"));
+  // Renesas RA4M1 – WFI is available via CMSIS on this Arm core.
+  // The SysTick keeps running so micros() survives.
+  SERIAL_OUT.println(F_STR("Renesas RA4M1 Sleep (WFI / WFE):"));
   SERIAL_OUT.println();
-  SERIAL_OUT.println(F_STR("Use LowPower library for sleep control"));
 
-#elif defined(__AVR__)
-  SERIAL_OUT.println(F_STR("Modes: IDLE/ADC_NR/Power-down/Power-save/Standby"));
-
-  // Test idle mode timing
-  set_sleep_mode(SLEEP_MODE_IDLE);
-
-  // Use Timer0 interrupt to wake (happens frequently)
-  unsigned long idleStart = micros();
-  sleep_enable();
-  sleep_cpu();
-  sleep_disable();
-  unsigned long idleTime = micros() - idleStart;
-
-  SERIAL_OUT.print(F_STR("Idle wake: "));
-  SERIAL_OUT.print(idleTime);
+  // Single WFI (SysTick wakes us ~every 1 ms)
+  unsigned long ra4m1WfiSingle;
+  {
+    unsigned long t = micros();
+    __WFI();
+    ra4m1WfiSingle = micros() - t;
+  }
+  SERIAL_OUT.print(F_STR("  WFI single wake: "));
+  SERIAL_OUT.print(ra4m1WfiSingle);
   SERIAL_OUT.println(F_STR(" us"));
 
+  startBenchmark();
+  for (int i = 0; i < 100; i++) {
+    __WFI();
+  }
+  unsigned long ra4m1WfiTime = endBenchmark();
+  SERIAL_OUT.print(F_STR("  100x WFI: "));
+  SERIAL_OUT.print(ra4m1WfiTime);
+  SERIAL_OUT.println(F_STR(" us"));
+
+  // WFE
+  unsigned long ra4m1WfeSingle;
+  {
+    __SEV();
+    __WFE();
+    unsigned long t = micros();
+    __WFE();
+    ra4m1WfeSingle = micros() - t;
+  }
+  SERIAL_OUT.print(F_STR("  WFE single wake: "));
+  SERIAL_OUT.print(ra4m1WfeSingle);
+  SERIAL_OUT.println(F_STR(" us"));
+
+  startBenchmark();
+  for (int i = 0; i < 100; i++) {
+    __SEV();
+    __WFE();
+    __WFE();
+  }
+  unsigned long ra4m1WfeTime = endBenchmark();
+  SERIAL_OUT.print(F_STR("  100x WFE: "));
+  SERIAL_OUT.print(ra4m1WfeTime);
+  SERIAL_OUT.println(F_STR(" us"));
+
+#elif defined(BOARD_SAMD)
+  // SAMD21/51 – Cortex-M0+/M4: IDLE modes keep SysTick running.
+  // PM->SLEEP.reg selects idle depth (IDLE0/1/2 on SAMD21, IDLE on SAMD51).
+  SERIAL_OUT.println(F_STR("SAMD Sleep (IDLE + WFI/WFE):"));
+  SERIAL_OUT.println();
+
+  // --- Idle 0 (CPU halted, AHB/APB clocks run) ---
+#if defined(__SAMD51__)
+  PM->SLEEPCFG.reg = PM_SLEEPCFG_SLEEPMODE_IDLE;
+  while (PM->SLEEPCFG.reg != PM_SLEEPCFG_SLEEPMODE_IDLE) {}  // sync
 #else
-  SERIAL_OUT.println(F_STR("Sleep mode info not available for this board"));
+  // SAMD21: Use SCB directly, PM->SLEEP.reg for idle depth
+  SCB->SCR &= ~SCB_SCR_SLEEPDEEP_Msk;  // select idle (not standby)
+  PM->SLEEP.reg = PM_SLEEP_IDLE_CPU;    // IDLE 0: halt CPU only
+#endif
+
+  unsigned long samdIdleSingle;
+  {
+    unsigned long t = micros();
+    __WFI();
+    samdIdleSingle = micros() - t;
+  }
+  SERIAL_OUT.print(F_STR("  IDLE WFI single: "));
+  SERIAL_OUT.print(samdIdleSingle);
+  SERIAL_OUT.println(F_STR(" us"));
+
+  startBenchmark();
+  for (int i = 0; i < 100; i++) {
+    __WFI();
+  }
+  unsigned long samdWfiTime = endBenchmark();
+  SERIAL_OUT.print(F_STR("  100x IDLE WFI: "));
+  SERIAL_OUT.print(samdWfiTime);
+  SERIAL_OUT.println(F_STR(" us"));
+
+  // WFE
+  unsigned long samdWfeSingle;
+  {
+    __SEV();
+    __WFE();
+    unsigned long t = micros();
+    __WFE();
+    samdWfeSingle = micros() - t;
+  }
+  SERIAL_OUT.print(F_STR("  IDLE WFE single: "));
+  SERIAL_OUT.print(samdWfeSingle);
+  SERIAL_OUT.println(F_STR(" us"));
+
+  startBenchmark();
+  for (int i = 0; i < 100; i++) {
+    __SEV();
+    __WFE();
+    __WFE();
+  }
+  unsigned long samdWfeTime = endBenchmark();
+  SERIAL_OUT.print(F_STR("  100x IDLE WFE: "));
+  SERIAL_OUT.print(samdWfeTime);
+  SERIAL_OUT.println(F_STR(" us"));
+
+#if !defined(__SAMD51__)
+  // SAMD21 deeper idle: IDLE 2 (CPU + AHB halted, APB still runs)
+  PM->SLEEP.reg = PM_SLEEP_IDLE_APB;  // IDLE 2
+  startBenchmark();
+  for (int i = 0; i < 100; i++) {
+    __WFI();
+  }
+  unsigned long samdIdle2Time = endBenchmark();
+  SERIAL_OUT.print(F_STR("  100x IDLE2 WFI: "));
+  SERIAL_OUT.print(samdIdle2Time);
+  SERIAL_OUT.println(F_STR(" us"));
+
+  // Restore IDLE 0
+  PM->SLEEP.reg = PM_SLEEP_IDLE_CPU;
+#endif
+
+#elif defined(BOARD_NRF52)
+  // nRF52840 – Cortex-M4F: System ON idle mode (WFI).
+  // SysTick keeps running; "System ON" is the only mode that preserves it.
+  // "System OFF" is a deep-sleep reset – we skip that.
+  SERIAL_OUT.println(F_STR("nRF52 Sleep (System ON, WFI/WFE):"));
+  SERIAL_OUT.println();
+
+  unsigned long nrfWfiSingle;
+  {
+    unsigned long t = micros();
+    __WFI();
+    nrfWfiSingle = micros() - t;
+  }
+  SERIAL_OUT.print(F_STR("  WFI single wake: "));
+  SERIAL_OUT.print(nrfWfiSingle);
+  SERIAL_OUT.println(F_STR(" us"));
+
+  startBenchmark();
+  for (int i = 0; i < 100; i++) {
+    __WFI();
+  }
+  unsigned long nrfWfiTime = endBenchmark();
+  SERIAL_OUT.print(F_STR("  100x WFI: "));
+  SERIAL_OUT.print(nrfWfiTime);
+  SERIAL_OUT.println(F_STR(" us"));
+
+  // WFE
+  unsigned long nrfWfeSingle;
+  {
+    __SEV();
+    __WFE();
+    unsigned long t = micros();
+    __WFE();
+    nrfWfeSingle = micros() - t;
+  }
+  SERIAL_OUT.print(F_STR("  WFE single wake: "));
+  SERIAL_OUT.print(nrfWfeSingle);
+  SERIAL_OUT.println(F_STR(" us"));
+
+  startBenchmark();
+  for (int i = 0; i < 100; i++) {
+    __SEV();
+    __WFE();
+    __WFE();
+  }
+  unsigned long nrfWfeTime = endBenchmark();
+  SERIAL_OUT.print(F_STR("  100x WFE: "));
+  SERIAL_OUT.print(nrfWfeTime);
+  SERIAL_OUT.println(F_STR(" us"));
+
+#elif defined(BOARD_STM32H7)
+  // STM32H7 (Portenta H7, Giga R1) – Cortex-M7
+  // D1 domain CSTOP = idle-sleep; deeper modes reset or need complex setup.
+  // HAL_PWR_EnterSLEEPMode keeps SysTick alive.
+  SERIAL_OUT.println(F_STR("STM32H7 Sleep (WFI/WFE):"));
+  SERIAL_OUT.println();
+
+  unsigned long stm32WfiSingle;
+  {
+    unsigned long t = micros();
+    __WFI();
+    stm32WfiSingle = micros() - t;
+  }
+  SERIAL_OUT.print(F_STR("  WFI single wake: "));
+  SERIAL_OUT.print(stm32WfiSingle);
+  SERIAL_OUT.println(F_STR(" us"));
+
+  startBenchmark();
+  for (int i = 0; i < 100; i++) {
+    __WFI();
+  }
+  unsigned long stm32WfiTime = endBenchmark();
+  SERIAL_OUT.print(F_STR("  100x WFI: "));
+  SERIAL_OUT.print(stm32WfiTime);
+  SERIAL_OUT.println(F_STR(" us"));
+
+  unsigned long stm32WfeSingle;
+  {
+    __SEV();
+    __WFE();
+    unsigned long t = micros();
+    __WFE();
+    stm32WfeSingle = micros() - t;
+  }
+  SERIAL_OUT.print(F_STR("  WFE single wake: "));
+  SERIAL_OUT.print(stm32WfeSingle);
+  SERIAL_OUT.println(F_STR(" us"));
+
+  startBenchmark();
+  for (int i = 0; i < 100; i++) {
+    __SEV();
+    __WFE();
+    __WFE();
+  }
+  unsigned long stm32WfeTime = endBenchmark();
+  SERIAL_OUT.print(F_STR("  100x WFE: "));
+  SERIAL_OUT.print(stm32WfeTime);
+  SERIAL_OUT.println(F_STR(" us"));
+
+#elif defined(TEENSYDUINO) && defined(__IMXRT1062__)
+  // Teensy 4.0/4.1 – Cortex-M7 (iMXRT1062)
+  // WFI enters "wait mode"; SysTick keeps ticking.
+  SERIAL_OUT.println(F_STR("Teensy 4.x Sleep (WFI/WFE):"));
+  SERIAL_OUT.println();
+
+  unsigned long teensyWfiSingle;
+  {
+    unsigned long t = micros();
+    asm volatile("wfi");
+    teensyWfiSingle = micros() - t;
+  }
+  SERIAL_OUT.print(F_STR("  WFI single wake: "));
+  SERIAL_OUT.print(teensyWfiSingle);
+  SERIAL_OUT.println(F_STR(" us"));
+
+  startBenchmark();
+  for (int i = 0; i < 100; i++) {
+    asm volatile("wfi");
+  }
+  unsigned long teensyWfiTime = endBenchmark();
+  SERIAL_OUT.print(F_STR("  100x WFI: "));
+  SERIAL_OUT.print(teensyWfiTime);
+  SERIAL_OUT.println(F_STR(" us"));
+
+  unsigned long teensyWfeSingle;
+  {
+    asm volatile("sev");
+    asm volatile("wfe");
+    unsigned long t = micros();
+    asm volatile("wfe");
+    teensyWfeSingle = micros() - t;
+  }
+  SERIAL_OUT.print(F_STR("  WFE single wake: "));
+  SERIAL_OUT.print(teensyWfeSingle);
+  SERIAL_OUT.println(F_STR(" us"));
+
+  startBenchmark();
+  for (int i = 0; i < 100; i++) {
+    asm volatile("sev");
+    asm volatile("wfe");
+    asm volatile("wfe");
+  }
+  unsigned long teensyWfeTime = endBenchmark();
+  SERIAL_OUT.print(F_STR("  100x WFE: "));
+  SERIAL_OUT.print(teensyWfeTime);
+  SERIAL_OUT.println(F_STR(" us"));
+
+#elif defined(TEENSYDUINO)
+  // Teensy 3.x (Cortex-M4) – same WFI approach
+  SERIAL_OUT.println(F_STR("Teensy 3.x Sleep (WFI):"));
+  SERIAL_OUT.println();
+
+  unsigned long t3WfiSingle;
+  {
+    unsigned long t = micros();
+    asm volatile("wfi");
+    t3WfiSingle = micros() - t;
+  }
+  SERIAL_OUT.print(F_STR("  WFI single wake: "));
+  SERIAL_OUT.print(t3WfiSingle);
+  SERIAL_OUT.println(F_STR(" us"));
+
+  startBenchmark();
+  for (int i = 0; i < 100; i++) {
+    asm volatile("wfi");
+  }
+  unsigned long t3WfiTime = endBenchmark();
+  SERIAL_OUT.print(F_STR("  100x WFI: "));
+  SERIAL_OUT.print(t3WfiTime);
+  SERIAL_OUT.println(F_STR(" us"));
+
+#elif defined(__AVR__)
+  // AVR – IDLE keeps Timer0 (millis/micros tick) alive.
+  // ADC Noise Reduction also keeps Timer0 but halts more peripherals.
+  // Power-down/save/standby stop Timer0 → we can't measure those with micros().
+  SERIAL_OUT.println(F_STR("AVR Sleep Modes (timer-based wake):"));
+  SERIAL_OUT.println();
+
+  // --- SLEEP_MODE_IDLE ---
+  set_sleep_mode(SLEEP_MODE_IDLE);
+  unsigned long avrIdleSingle;
+  {
+    unsigned long t = micros();
+    sleep_enable();
+    sleep_cpu();
+    sleep_disable();
+    avrIdleSingle = micros() - t;
+  }
+  SERIAL_OUT.print(F_STR("  IDLE single wake: "));
+  SERIAL_OUT.print(avrIdleSingle);
+  SERIAL_OUT.println(F_STR(" us"));
+
+  startBenchmark();
+  for (int i = 0; i < 100; i++) {
+    sleep_enable();
+    sleep_cpu();
+    sleep_disable();
+  }
+  unsigned long avrIdleTime = endBenchmark();
+  SERIAL_OUT.print(F_STR("  100x IDLE: "));
+  SERIAL_OUT.print(avrIdleTime);
+  SERIAL_OUT.println(F_STR(" us"));
+
+  // --- SLEEP_MODE_ADC (ADC Noise Reduction) ---
+  // Only available on mega-class AVR (ATmega328P, ATmega2560, etc.)
+#if defined(SLEEP_MODE_ADC)
+  set_sleep_mode(SLEEP_MODE_ADC);
+  unsigned long avrAdcSingle;
+  {
+    unsigned long t = micros();
+    sleep_enable();
+    sleep_cpu();
+    sleep_disable();
+    avrAdcSingle = micros() - t;
+  }
+  SERIAL_OUT.print(F_STR("  ADC NR single wake: "));
+  SERIAL_OUT.print(avrAdcSingle);
+  SERIAL_OUT.println(F_STR(" us"));
+
+  startBenchmark();
+  for (int i = 0; i < 100; i++) {
+    sleep_enable();
+    sleep_cpu();
+    sleep_disable();
+  }
+  unsigned long avrAdcTime = endBenchmark();
+  SERIAL_OUT.print(F_STR("  100x ADC NR: "));
+  SERIAL_OUT.print(avrAdcTime);
+  SERIAL_OUT.println(F_STR(" us"));
+#endif
+
+  // Restore idle mode
+  set_sleep_mode(SLEEP_MODE_IDLE);
+
+#else
+  SERIAL_OUT.println(F_STR("Sleep mode test not available for this board"));
 #endif
 }
 // ==================== SYSTEM INFO ====================


### PR DESCRIPTION
Sleep modes (Part2):
- ESP8266: waiti-0 idle sleep benchmark
- RP2040: WFI + WFE with single and 100x batch measurements
- Renesas RA4M1: actual WFI/WFE tests (replaces info-only stub)
- SAMD21/51: IDLE WFI/WFE + deeper IDLE2 mode on SAMD21
- nRF52840: System ON idle via WFI/WFE
- STM32H7: WFI/WFE (Portenta H7, Giga R1)
- Teensy 4.x: WFI/WFE via inline asm
- Teensy 3.x: WFI via inline asm
- AVR: expanded to test both IDLE and ADC Noise Reduction modes with 100x batch timing for each

Interrupt latency (Part1):
- Two-pass measurement: Pass 1 uses digitalWrite (real-world), Pass 2 uses direct port/register toggle (pure ISR entry latency)
- Reports both numbers + the computed digitalWrite overhead
- Direct port macros for AVR, ESP32 (all variants), RP2040; other boards fall back to digitalWrite for pass 2

https://claude.ai/code/session_01VRgRspZFXeq75xaNXqbxVD