### PR TITLE
Require ArduinoBLE on Uno R4 WiFi and always run BLE discovery benchmark

### DIFF
--- a/Part2_PlatformBenchmarks/Part2_PlatformBenchmarks.ino
+++ b/Part2_PlatformBenchmarks/Part2_PlatformBenchmarks.ino
@@ -121,6 +121,7 @@
 #include <WiFiS3.h>
 #include <EEPROM.h>
 #include "Arduino_LED_Matrix.h"
+#include <ArduinoBLE.h>
 #elif defined(ARDUINO_UNOR4_MINIMA)
 #define BOARD_NAME "Arduino Uno R4 Minima"
 #define HAS_LED_MATRIX
@@ -3783,13 +3784,49 @@ void benchmarkUnoR4BLE() {
   SERIAL_OUT.println(F_STR("Uno R4 WiFi has BLE via ESP32-S3 module"));
   SERIAL_OUT.println(F_STR("BLE requires ArduinoBLE library"));
   SERIAL_OUT.println();
-  SERIAL_OUT.println(F_STR("To use BLE on Uno R4 WiFi:"));
-  SERIAL_OUT.println(F_STR("  1. Install ArduinoBLE library"));
-  SERIAL_OUT.println(F_STR("  2. #include <ArduinoBLE.h>"));
-  SERIAL_OUT.println(F_STR("  3. Call BLE.begin()"));
-  SERIAL_OUT.println(F_STR("  4. Use BLE.scan() for device discovery"));
-  SERIAL_OUT.println();
-  SERIAL_OUT.println(F_STR("Note: Full BLE benchmark requires ArduinoBLE"));
+
+  SERIAL_OUT.println(F_STR("Running BLE discovery benchmark with ArduinoBLE..."));
+
+  if (!BLE.begin()) {
+    SERIAL_OUT.println(F_STR("BLE.begin() failed (check firmware/module state)"));
+    return;
+  }
+
+  SERIAL_OUT.println(F_STR("Calling BLE.scan() for device discovery (5 sec)..."));
+  unsigned long startMicros = micros();
+  BLE.scan();
+
+  int discovered = 0;
+  unsigned long scanStartMs = millis();
+  while (millis() - scanStartMs < 5000) {
+    BLEDevice peripheral = BLE.available();
+    if (!peripheral) {
+      continue;
+    }
+
+    discovered++;
+    SERIAL_OUT.print(F_STR("  Found #"));
+    SERIAL_OUT.print(discovered);
+    SERIAL_OUT.print(F_STR(": "));
+    if (peripheral.localName().length()) {
+      SERIAL_OUT.print(peripheral.localName());
+    } else {
+      SERIAL_OUT.print(F_STR("(unnamed)"));
+    }
+    SERIAL_OUT.print(F_STR(" ["));
+    SERIAL_OUT.print(peripheral.address());
+    SERIAL_OUT.println(F_STR("]"));
+  }
+
+  BLE.stopScan();
+  BLE.end();
+
+  unsigned long elapsedMicros = micros() - startMicros;
+  SERIAL_OUT.print(F_STR("Discovered devices: "));
+  SERIAL_OUT.println(discovered);
+  SERIAL_OUT.print(F_STR("Scan elapsed: "));
+  SERIAL_OUT.print(elapsedMicros / 1000.0f, 2);
+  SERIAL_OUT.println(F_STR(" ms"));
 }
 #endif
 


### PR DESCRIPTION
### Motivation
- The Uno R4 WiFi benchmark was printing an instructional fallback instead of executing a real BLE scan because the previous `__has_include(<ArduinoBLE.h>)` gating prevented using `ArduinoBLE` in your environment.
- The change ensures the benchmark runs the active discovery flow so BLE scans behave as intended on the Uno R4 WiFi (ESP32-S3 module). 

### Description
- Unconditionally include `ArduinoBLE.h` for `ARDUINO_UNOR4_WIFI` instead of using `__has_include` detection so the BLE API is available at compile time (`#include <ArduinoBLE.h>`). 
- Remove the compile-time fallback instructional block and always execute the active ArduinoBLE discovery flow: call `BLE.begin()`, call `BLE.scan()`, poll `BLE.available()` for 5 seconds, then `BLE.stopScan()` and `BLE.end()` and print results. 
- Improve the runtime failure message to `BLE.begin()` to hint at firmware/module state when initialization fails. 

### Testing
- Ran `rg -n "Running BLE discovery benchmark with ArduinoBLE|To use BLE on Uno R4 WiFi|#include <ArduinoBLE.h>" Part2_PlatformBenchmarks/Part2_PlatformBenchmarks.ino` to verify the new include and runtime message were present (succeeded). 
- Committed the change to the local repo (commit succeeded). 
- Compile validation was not performed because `arduino-cli`/toolchain was not available in this environment (not run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991be5d7b4883319d791827bb3c2325)