### PR TITLE
Reduce Yun I2C benchmark stall window and add progress output

### DIFF
--- a/Part2_PlatformBenchmarks/Part2_PlatformBenchmarks.ino
+++ b/Part2_PlatformBenchmarks/Part2_PlatformBenchmarks.ino
@@ -3834,6 +3834,66 @@ void benchmarkUnoR4BLE() {
 // ==================== I2C WIRE COMMUNICATION ====================
 
 #if !defined(ARDUINO_UNO_Q)
+static void runI2CWriteBenchmark(const __FlashStringHelper* label, uint32_t clockHz, int iterations, int progressStep) {
+  uint16_t statusCounts[6] = {0, 0, 0, 0, 0, 0};
+
+  Wire.setClock(clockHz);
+  startBenchmark();
+
+  int completed = 0;
+  for (int i = 0; i < iterations; i++) {
+    if (progressStep > 0 && i > 0 && (i % progressStep) == 0) {
+      SERIAL_OUT.print(F_STR("."));
+    }
+    Wire.beginTransmission(0x08);
+    Wire.write(i & 0xFF);
+    uint8_t status = Wire.endTransmission();
+
+    if (status < 6) {
+      statusCounts[status]++;
+    } else {
+      statusCounts[4]++;
+    }
+
+    completed++;
+
+    // Abort early if the bus repeatedly reports hard failures/timeouts.
+    if ((statusCounts[4] + statusCounts[5]) >= 10) {
+      break;
+    }
+  }
+
+  unsigned long elapsed = endBenchmark();
+
+  if (progressStep > 0) {
+    SERIAL_OUT.println();
+  }
+
+  SERIAL_OUT.print(label);
+  SERIAL_OUT.print(F_STR(": "));
+  SERIAL_OUT.print(elapsed);
+  SERIAL_OUT.print(F_STR(" us for "));
+  SERIAL_OUT.print(completed);
+  SERIAL_OUT.print(F_STR(" writes ("));
+  SERIAL_OUT.print((completed > 0 && elapsed > 0) ? (completed * 1000.0f / elapsed) : 0.0f);
+  SERIAL_OUT.println(F_STR(" txn/ms)"));
+
+  SERIAL_OUT.print(F_STR("  Status codes: ok="));
+  SERIAL_OUT.print(statusCounts[0]);
+  SERIAL_OUT.print(F_STR(", addrNACK="));
+  SERIAL_OUT.print(statusCounts[2]);
+  SERIAL_OUT.print(F_STR(", dataNACK="));
+  SERIAL_OUT.print(statusCounts[3]);
+  SERIAL_OUT.print(F_STR(", other="));
+  SERIAL_OUT.print(statusCounts[4]);
+  SERIAL_OUT.print(F_STR(", timeout="));
+  SERIAL_OUT.println(statusCounts[5]);
+
+  if (completed < iterations) {
+    SERIAL_OUT.println(F_STR("  Early stop: repeated bus errors/timeouts"));
+  }
+}
+
 void benchmarkWireI2C() {
   printHeader("I/O: WIRE I2C COMMUNICATION");
 
@@ -3872,59 +3932,30 @@ void benchmarkWireI2C() {
 
   Wire.begin();
 
+#if defined(WIRE_HAS_TIMEOUT)
+  Wire.setWireTimeout(3000, true);  // 3ms per transaction to avoid long stalls on stuck bus
+  SERIAL_OUT.println(F_STR("I2C timeout guard: enabled (3 ms)"));
+#endif
+
   SERIAL_OUT.println();
   SERIAL_OUT.println(F_STR("Testing I2C transaction speed"));
   SERIAL_OUT.println(F_STR("(No device - measuring bus overhead)"));
   SERIAL_OUT.println();
 
-  // Standard mode (100 kHz)
-  Wire.setClock(100000);
-  startBenchmark();
-  for (int i = 0; i < 1000; i++) {
-    Wire.beginTransmission(0x08);
-    Wire.write(i & 0xFF);
-    Wire.endTransmission();
-  }
-  unsigned long stdTime = endBenchmark();
+#if defined(ARDUINO_AVR_YUN)
+  const int i2cIterations = 60;
+  const int i2cProgressStep = 5;
+  SERIAL_OUT.println(F_STR("Yun profile: reduced iterations to avoid long blocking waits"));
+#else
+  const int i2cIterations = 1000;
+  const int i2cProgressStep = 0;
+#endif
 
-  SERIAL_OUT.print(F_STR("100 kHz: "));
-  SERIAL_OUT.print(stdTime);
-  SERIAL_OUT.print(F_STR(" us for 1000 writes ("));
-  SERIAL_OUT.print(1000.0 / stdTime * 1000);
-  SERIAL_OUT.println(F_STR(" txn/ms)"));
-
-  // Fast mode (400 kHz)
-  Wire.setClock(400000);
-  startBenchmark();
-  for (int i = 0; i < 1000; i++) {
-    Wire.beginTransmission(0x08);
-    Wire.write(i & 0xFF);
-    Wire.endTransmission();
-  }
-  unsigned long fastTime = endBenchmark();
-
-  SERIAL_OUT.print(F_STR("400 kHz: "));
-  SERIAL_OUT.print(fastTime);
-  SERIAL_OUT.print(F_STR(" us for 1000 writes ("));
-  SERIAL_OUT.print(1000.0 / fastTime * 1000);
-  SERIAL_OUT.println(F_STR(" txn/ms)"));
+  runI2CWriteBenchmark(F_STR("100 kHz"), 100000, i2cIterations, i2cProgressStep);
+  runI2CWriteBenchmark(F_STR("400 kHz"), 400000, i2cIterations, i2cProgressStep);
 
 #if defined(ESP32) || defined(ARDUINO_ARCH_RP2040) || defined(BOARD_STM32H7)
-  // Fast mode plus (1 MHz) on capable boards
-  Wire.setClock(1000000);
-  startBenchmark();
-  for (int i = 0; i < 1000; i++) {
-    Wire.beginTransmission(0x08);
-    Wire.write(i & 0xFF);
-    Wire.endTransmission();
-  }
-  unsigned long fastPlusTime = endBenchmark();
-
-  SERIAL_OUT.print(F_STR("1 MHz:   "));
-  SERIAL_OUT.print(fastPlusTime);
-  SERIAL_OUT.print(F_STR(" us for 1000 writes ("));
-  SERIAL_OUT.print(1000.0 / fastPlusTime * 1000);
-  SERIAL_OUT.println(F_STR(" txn/ms)"));
+  runI2CWriteBenchmark(F_STR("1 MHz"), 1000000, i2cIterations, i2cProgressStep);
 #endif
 
 #if defined(ESP32) && !defined(CONFIG_IDF_TARGET_ESP32C3) && !defined(CONFIG_IDF_TARGET_ESP32C6) && !defined(CONFIG_IDF_TARGET_ESP32H2)


### PR DESCRIPTION
### Motivation

- Prevent long apparent freezes during I2C benchmarks on Arduino Yun caused by blocking `Wire.endTransmission()` calls when the bus/device is in a bad state. 
- Improve serial responsiveness and visibility during long benchmark loops so users see progress instead of a long pause.

### Description

- Added an optional `progressStep` parameter to `runI2CWriteBenchmark` and print `.` progress markers every `progressStep` iterations to provide live feedback during long loops. 
- Introduced a Yun-specific profile that reduces `i2cIterations` from `1000` to `60` and sets `i2cProgressStep` to `5` to cap worst-case stall time on `ARDUINO_AVR_YUN`. 
- Updated all I2C benchmark invocations to use the new helper signature so 100 kHz / 400 kHz / (where supported) 1 MHz runs receive the progress behavior. 
- Enabled an optional timeout guard under `WIRE_HAS_TIMEOUT` via `Wire.setWireTimeout(3000, true)` to limit per-transaction blocking on platforms that support the feature, and preserved the existing status counting and early-abort logic.

### Testing

- Performed an automated code search for `runI2CWriteBenchmark(`, `i2cIterations`, and `Yun profile` to verify all call sites and the new Yun profile were added and updated successfully. 
- Inspected the modified region of `Part2_PlatformBenchmarks/Part2_PlatformBenchmarks.ino` to confirm the new `progressStep` logic, progress newline formatting, and conditional Yun profile are present and placed correctly. 
- Verified that the change is a localized modification to the I2C benchmark logic with no other files affected and that status/error accounting and early abort behavior remain intact.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991c4a79bc4833196f0ac43dc12e66b)