### PR TITLE
Add standalone I2C_test sketch and integrate progress/timeout into I2C benchmark

### DIFF
--- a/I2C_test.ino
+++ b/I2C_test.ino
@@ -1,0 +1,178 @@
+/*
+ * Standalone I2C Wire benchmark test extracted from Part2_PlatformBenchmarks
+ * Runs only the I2C benchmark section.
+ */
+
+#include <Arduino.h>
+#include <Wire.h>
+
+#ifndef F_STR
+#define F_STR(x) F(x)
+#endif
+
+#define SERIAL_OUT Serial
+
+static unsigned long benchmarkStartMicros = 0;
+
+static inline void startBenchmark() {
+  benchmarkStartMicros = micros();
+}
+
+static inline unsigned long endBenchmark() {
+  return micros() - benchmarkStartMicros;
+}
+
+static void printHeader(const char* title) {
+  SERIAL_OUT.println();
+  SERIAL_OUT.println(F_STR("========================================"));
+  SERIAL_OUT.println(title);
+  SERIAL_OUT.println(F_STR("========================================"));
+}
+
+static void runI2CWriteBenchmark(const __FlashStringHelper* label, uint32_t clockHz, int iterations, int progressStep) {
+  uint16_t statusCounts[6] = {0, 0, 0, 0, 0, 0};
+
+  Wire.setClock(clockHz);
+  startBenchmark();
+
+  int completed = 0;
+  for (int i = 0; i < iterations; i++) {
+    if (progressStep > 0 && i > 0 && (i % progressStep) == 0) {
+      SERIAL_OUT.print(F_STR("."));
+    }
+
+    Wire.beginTransmission(0x08);
+    Wire.write(i & 0xFF);
+    uint8_t status = Wire.endTransmission();
+
+    if (status < 6) {
+      statusCounts[status]++;
+    } else {
+      statusCounts[4]++;
+    }
+
+    completed++;
+
+    // Abort early if the bus repeatedly reports hard failures/timeouts.
+    if ((statusCounts[4] + statusCounts[5]) >= 10) {
+      break;
+    }
+  }
+
+  unsigned long elapsed = endBenchmark();
+
+  if (progressStep > 0) {
+    SERIAL_OUT.println();
+  }
+
+  SERIAL_OUT.print(label);
+  SERIAL_OUT.print(F_STR(": "));
+  SERIAL_OUT.print(elapsed);
+  SERIAL_OUT.print(F_STR(" us for "));
+  SERIAL_OUT.print(completed);
+  SERIAL_OUT.print(F_STR(" writes ("));
+  SERIAL_OUT.print((completed > 0 && elapsed > 0) ? (completed * 1000.0f / elapsed) : 0.0f);
+  SERIAL_OUT.println(F_STR(" txn/ms)"));
+
+  SERIAL_OUT.print(F_STR("  Status codes: ok="));
+  SERIAL_OUT.print(statusCounts[0]);
+  SERIAL_OUT.print(F_STR(", addrNACK="));
+  SERIAL_OUT.print(statusCounts[2]);
+  SERIAL_OUT.print(F_STR(", dataNACK="));
+  SERIAL_OUT.print(statusCounts[3]);
+  SERIAL_OUT.print(F_STR(", other="));
+  SERIAL_OUT.print(statusCounts[4]);
+  SERIAL_OUT.print(F_STR(", timeout="));
+  SERIAL_OUT.println(statusCounts[5]);
+
+  if (completed < iterations) {
+    SERIAL_OUT.println(F_STR("  Early stop: repeated bus errors/timeouts"));
+  }
+}
+
+static void benchmarkWireI2C() {
+  printHeader("I/O: WIRE I2C COMMUNICATION");
+
+  // Number of I2C buses
+  SERIAL_OUT.print(F_STR("I2C buses: "));
+#if defined(WIRE_INTERFACES_COUNT)
+  SERIAL_OUT.println(WIRE_INTERFACES_COUNT);
+#elif defined(ESP32)
+  SERIAL_OUT.println(2);
+#elif defined(ARDUINO_ARCH_RP2040)
+  SERIAL_OUT.println(2);
+#elif defined(ARDUINO_SAM_DUE)
+  SERIAL_OUT.println(2);
+#elif defined(BOARD_STM32H7)
+  SERIAL_OUT.println(3);
+#elif defined(BOARD_NRF52)
+  SERIAL_OUT.println(2);
+#else
+  SERIAL_OUT.println(1);
+#endif
+
+  // Internal buffer size
+  SERIAL_OUT.print(F_STR("Buffer size: "));
+#if defined(BUFFER_LENGTH)
+  SERIAL_OUT.print(BUFFER_LENGTH);
+  SERIAL_OUT.println(F_STR(" bytes"));
+#elif defined(I2C_BUFFER_LENGTH)
+  SERIAL_OUT.print(I2C_BUFFER_LENGTH);
+  SERIAL_OUT.println(F_STR(" bytes"));
+#elif defined(WIRE_BUFFER_LENGTH)
+  SERIAL_OUT.print(WIRE_BUFFER_LENGTH);
+  SERIAL_OUT.println(F_STR(" bytes"));
+#else
+  SERIAL_OUT.println(F_STR("unknown"));
+#endif
+
+  Wire.begin();
+
+#if defined(WIRE_HAS_TIMEOUT)
+  Wire.setWireTimeout(3000, true);  // 3ms per transaction to avoid long stalls on stuck bus
+  SERIAL_OUT.println(F_STR("I2C timeout guard: enabled (3 ms)"));
+#endif
+
+  SERIAL_OUT.println();
+  SERIAL_OUT.println(F_STR("Testing I2C transaction speed"));
+  SERIAL_OUT.println(F_STR("(No device - measuring bus overhead)"));
+  SERIAL_OUT.println();
+
+#if defined(ARDUINO_AVR_YUN)
+  const int i2cIterations = 60;
+  const int i2cProgressStep = 5;
+  SERIAL_OUT.println(F_STR("Yun profile: reduced iterations to avoid long blocking waits"));
+#else
+  const int i2cIterations = 1000;
+  const int i2cProgressStep = 0;
+#endif
+
+  runI2CWriteBenchmark(F_STR("100 kHz"), 100000, i2cIterations, i2cProgressStep);
+  runI2CWriteBenchmark(F_STR("400 kHz"), 400000, i2cIterations, i2cProgressStep);
+
+#if defined(ESP32) || defined(ARDUINO_ARCH_RP2040) || defined(BOARD_STM32H7)
+  runI2CWriteBenchmark(F_STR("1 MHz"), 1000000, i2cIterations, i2cProgressStep);
+#endif
+
+#if defined(ESP32) && !defined(CONFIG_IDF_TARGET_ESP32C3) && !defined(CONFIG_IDF_TARGET_ESP32C6) && !defined(CONFIG_IDF_TARGET_ESP32H2)
+  Wire.end();
+#endif
+}
+
+void setup() {
+  SERIAL_OUT.begin(115200);
+
+#if defined(USBCON)
+  unsigned long waitStart = millis();
+  while (!SERIAL_OUT && millis() - waitStart < 3000) {
+    delay(10);
+  }
+#endif
+
+  delay(300);
+  benchmarkWireI2C();
+}
+
+void loop() {
+  // Intentionally empty: run once.
+}

--- a/Part2_PlatformBenchmarks/Part2_PlatformBenchmarks.ino
+++ b/Part2_PlatformBenchmarks/Part2_PlatformBenchmarks.ino
@@ -3834,6 +3834,66 @@ void benchmarkUnoR4BLE() {
 // ==================== I2C WIRE COMMUNICATION ====================
 
 #if !defined(ARDUINO_UNO_Q)
+static void runI2CWriteBenchmark(const __FlashStringHelper* label, uint32_t clockHz, int iterations, int progressStep) {
+  uint16_t statusCounts[6] = {0, 0, 0, 0, 0, 0};
+
+  Wire.setClock(clockHz);
+  startBenchmark();
+
+  int completed = 0;
+  for (int i = 0; i < iterations; i++) {
+    if (progressStep > 0 && i > 0 && (i % progressStep) == 0) {
+      SERIAL_OUT.print(F_STR("."));
+    }
+    Wire.beginTransmission(0x08);
+    Wire.write(i & 0xFF);
+    uint8_t status = Wire.endTransmission();
+
+    if (status < 6) {
+      statusCounts[status]++;
+    } else {
+      statusCounts[4]++;
+    }
+
+    completed++;
+
+    // Abort early if the bus repeatedly reports hard failures/timeouts.
+    if ((statusCounts[4] + statusCounts[5]) >= 10) {
+      break;
+    }
+  }
+
+  unsigned long elapsed = endBenchmark();
+
+  if (progressStep > 0) {
+    SERIAL_OUT.println();
+  }
+
+  SERIAL_OUT.print(label);
+  SERIAL_OUT.print(F_STR(": "));
+  SERIAL_OUT.print(elapsed);
+  SERIAL_OUT.print(F_STR(" us for "));
+  SERIAL_OUT.print(completed);
+  SERIAL_OUT.print(F_STR(" writes ("));
+  SERIAL_OUT.print((completed > 0 && elapsed > 0) ? (completed * 1000.0f / elapsed) : 0.0f);
+  SERIAL_OUT.println(F_STR(" txn/ms)"));
+
+  SERIAL_OUT.print(F_STR("  Status codes: ok="));
+  SERIAL_OUT.print(statusCounts[0]);
+  SERIAL_OUT.print(F_STR(", addrNACK="));
+  SERIAL_OUT.print(statusCounts[2]);
+  SERIAL_OUT.print(F_STR(", dataNACK="));
+  SERIAL_OUT.print(statusCounts[3]);
+  SERIAL_OUT.print(F_STR(", other="));
+  SERIAL_OUT.print(statusCounts[4]);
+  SERIAL_OUT.print(F_STR(", timeout="));
+  SERIAL_OUT.println(statusCounts[5]);
+
+  if (completed < iterations) {
+    SERIAL_OUT.println(F_STR("  Early stop: repeated bus errors/timeouts"));
+  }
+}
+
 void benchmarkWireI2C() {
   printHeader("I/O: WIRE I2C COMMUNICATION");
 
@@ -3872,59 +3932,30 @@ void benchmarkWireI2C() {
 
   Wire.begin();
 
+#if defined(WIRE_HAS_TIMEOUT)
+  Wire.setWireTimeout(3000, true);  // 3ms per transaction to avoid long stalls on stuck bus
+  SERIAL_OUT.println(F_STR("I2C timeout guard: enabled (3 ms)"));
+#endif
+
   SERIAL_OUT.println();
   SERIAL_OUT.println(F_STR("Testing I2C transaction speed"));
   SERIAL_OUT.println(F_STR("(No device - measuring bus overhead)"));
   SERIAL_OUT.println();
 
-  // Standard mode (100 kHz)
-  Wire.setClock(100000);
-  startBenchmark();
-  for (int i = 0; i < 1000; i++) {
-    Wire.beginTransmission(0x08);
-    Wire.write(i & 0xFF);
-    Wire.endTransmission();
-  }
-  unsigned long stdTime = endBenchmark();
+#if defined(ARDUINO_AVR_YUN)
+  const int i2cIterations = 60;
+  const int i2cProgressStep = 5;
+  SERIAL_OUT.println(F_STR("Yun profile: reduced iterations to avoid long blocking waits"));
+#else
+  const int i2cIterations = 1000;
+  const int i2cProgressStep = 0;
+#endif
 
-  SERIAL_OUT.print(F_STR("100 kHz: "));
-  SERIAL_OUT.print(stdTime);
-  SERIAL_OUT.print(F_STR(" us for 1000 writes ("));
-  SERIAL_OUT.print(1000.0 / stdTime * 1000);
-  SERIAL_OUT.println(F_STR(" txn/ms)"));
-
-  // Fast mode (400 kHz)
-  Wire.setClock(400000);
-  startBenchmark();
-  for (int i = 0; i < 1000; i++) {
-    Wire.beginTransmission(0x08);
-    Wire.write(i & 0xFF);
-    Wire.endTransmission();
-  }
-  unsigned long fastTime = endBenchmark();
-
-  SERIAL_OUT.print(F_STR("400 kHz: "));
-  SERIAL_OUT.print(fastTime);
-  SERIAL_OUT.print(F_STR(" us for 1000 writes ("));
-  SERIAL_OUT.print(1000.0 / fastTime * 1000);
-  SERIAL_OUT.println(F_STR(" txn/ms)"));
+  runI2CWriteBenchmark(F_STR("100 kHz"), 100000, i2cIterations, i2cProgressStep);
+  runI2CWriteBenchmark(F_STR("400 kHz"), 400000, i2cIterations, i2cProgressStep);
 
 #if defined(ESP32) || defined(ARDUINO_ARCH_RP2040) || defined(BOARD_STM32H7)
-  // Fast mode plus (1 MHz) on capable boards
-  Wire.setClock(1000000);
-  startBenchmark();
-  for (int i = 0; i < 1000; i++) {
-    Wire.beginTransmission(0x08);
-    Wire.write(i & 0xFF);
-    Wire.endTransmission();
-  }
-  unsigned long fastPlusTime = endBenchmark();
-
-  SERIAL_OUT.print(F_STR("1 MHz:   "));
-  SERIAL_OUT.print(fastPlusTime);
-  SERIAL_OUT.print(F_STR(" us for 1000 writes ("));
-  SERIAL_OUT.print(1000.0 / fastPlusTime * 1000);
-  SERIAL_OUT.println(F_STR(" txn/ms)"));
+  runI2CWriteBenchmark(F_STR("1 MHz"), 1000000, i2cIterations, i2cProgressStep);
 #endif
 
 #if defined(ESP32) && !defined(CONFIG_IDF_TARGET_ESP32C3) && !defined(CONFIG_IDF_TARGET_ESP32C6) && !defined(CONFIG_IDF_TARGET_ESP32H2)


### PR DESCRIPTION
### Motivation
- Allow running the I2C Wire benchmark in isolation for focused troubleshooting and reduce long blocking stalls observed on some boards (notably Yun) by adding progress visibility and limiting per-transaction blocking where supported.

### Description
- Added a new standalone sketch `I2C_test.ino` that contains only the I2C benchmark flow with a one-shot `setup()` and an empty `loop()` for independent upload/run.
- Introduced `runI2CWriteBenchmark(const __FlashStringHelper* label, uint32_t clockHz, int iterations, int progressStep)` into `Part2_PlatformBenchmarks.ino` and replaced the previous inline timing loops with calls to this helper.
- Implemented live progress markers (`.`) every `progressStep` iterations, Yun-specific profile (`i2cIterations = 60`, `i2cProgressStep = 5`) to cap worst-case stall time, and early-abort logic on repeated bus errors/timeouts.
- Enabled an optional timeout guard via `Wire.setWireTimeout(3000, true)` under `WIRE_HAS_TIMEOUT` and preserved status counting and reporting for each run (100 kHz, 400 kHz, and 1 MHz where supported).

### Testing
- Ran `git status --short && rg -n "benchmarkWireI2C|runI2CWriteBenchmark|void setup\(|void loop\(" I2C_test.ino` to verify the new file and symbol presence, which succeeded.
- Committed the new file with `git add I2C_test.ino && git commit -m "Add standalone I2C_test sketch for isolated Wire benchmark"`, and the commit succeeded.
- Printed `I2C_test.ino` contents via `nl -ba I2C_test.ino` to inspect the extracted benchmark logic, which matched the intended I2C-only test.
- Created a PR record via the automated `make_pr` step and the PR metadata was generated successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991c4a79bc4833196f0ac43dc12e66b)