### PR TITLE
Fix Teensy 4.x: use SCB_SCR / SCB_SCR_SEVONPEND (correct Teensyduino …

### DIFF
--- a/Part2_PlatformBenchmarks/Part2_PlatformBenchmarks.ino
+++ b/Part2_PlatformBenchmarks/Part2_PlatformBenchmarks.ino
@@ -4588,11 +4588,10 @@ void benchmarkSleepModes() {
   // WFE on Cortex-M7 only wakes on SEV or a pending interrupt when SEVONPEND
   // (SCR bit 4) is set.  Without it the second wfe blocks forever because
   // there is no second core to issue SEV and the iMXRT1062 defaults SEVONPEND=0.
-  // Teensyduino (imxrt.h) exposes the SCB System Control Register as
-  // ARM_SCB_SCR with bit constant ARM_SCB_SCR_SEVONPEND (not CMSIS SCB->SCR).
-  // Save SCR, enable SEVONPEND, run the WFE tests, then restore SCR.
-  uint32_t savedScr = ARM_SCB_SCR;
-  ARM_SCB_SCR |= ARM_SCB_SCR_SEVONPEND;
+  // Teensyduino defines the System Control Register as SCB_SCR and the bit
+  // as SCB_SCR_SEVONPEND.  Save SCR, enable SEVONPEND, run WFE tests, restore.
+  uint32_t savedScr = SCB_SCR;
+  SCB_SCR |= SCB_SCR_SEVONPEND;
 
   unsigned long teensyWfeSingle;
   {
@@ -4617,7 +4616,7 @@ void benchmarkSleepModes() {
   SERIAL_OUT.print(teensyWfeTime);
   SERIAL_OUT.println(F_STR(" us"));
 
-  ARM_SCB_SCR = savedScr;  // restore original SCR (clears SEVONPEND if it was 0)
+  SCB_SCR = savedScr;  // restore original SCR (clears SEVONPEND if it was 0)
 
 #elif defined(TEENSYDUINO)
   // Teensy 3.x (Cortex-M4) – same WFI approach


### PR DESCRIPTION
…names)

The compiler's 'did you mean' suggestion confirmed the correct identifiers: Teensyduino defines the System Control Register as SCB_SCR and the SEVONPEND bit as SCB_SCR_SEVONPEND (no ARM_ prefix, no _Msk suffix).

https://claude.ai/code/session_01AXCrT5CwfddNZeusDdyxdy