### PR TITLE
Remove unused helpers from BenchmarkHelpers.h in both parts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,7 @@ If you notice incorrect or missing data in the results spreadsheets:
 
 - All benchmark code must compile in the Arduino IDE with no external dependencies beyond board-specific platform libraries (exception: the Multiduino board detection block requires the Adafruit RTClib library)
 - Use `volatile` accumulators to prevent compiler optimization of benchmark loops
-- Use the timing helpers in `BenchmarkHelpers.h` (`runForAtLeastUs`, `runTimedLoop`) for consistent measurements
+- Use the timing helper in `BenchmarkHelpers.h` (`runTimedLoop`) for consistent measurements
 - Call `yield()` on RTOS-based platforms (ESP32, ESP8266, RP2040) inside long-running loops to avoid watchdog resets
 - Print results to Serial at 115200 baud in a format consistent with existing output
 - Wrap board-specific code in `#if defined(...)` / `#endif` preprocessor guards

--- a/Part1_CoreBenchmarks/BenchmarkHelpers.h
+++ b/Part1_CoreBenchmarks/BenchmarkHelpers.h
@@ -25,46 +25,12 @@ template<typename A>
 struct is_same<A, A> : true_type {};
 }  // namespace benchmark_detail
 
-struct MinDurationResult {
-  uint32_t ops;
-  unsigned long elapsedUs;
-};
-
-template<typename Func>
-MinDurationResult runForAtLeastUs(unsigned long minUs, Func fn) {
-  MinDurationResult result = {};
-  unsigned long start = micros();
-  unsigned long elapsed = 0;
-  do {
-    result.ops += fn();
-#if defined(ESP32) || defined(ESP8266) || defined(ARDUINO_ARCH_RP2040)
-    yield();
-#endif
-    elapsed = micros() - start;
-  } while (elapsed < minUs);
-  result.elapsedUs = elapsed;
-  return result;
-}
-
 struct TimedLoopResult {
   unsigned long elapsedMicros;
   uint32_t iterations;
   uint32_t totalOps;
   float opsPerMs;
 };
-
-// Helper function for void return type
-template<typename Func>
-void runFuncVoid(Func& func, bool& shouldBreak) {
-  func();
-  shouldBreak = false;
-}
-
-// Helper function for non-void return type
-template<typename Func>
-void runFuncNonVoid(Func& func, bool& shouldBreak) {
-  shouldBreak = !func();
-}
 
 template<typename Func>
 bool runFuncAndCheck(Func& func, benchmark_detail::true_type) {

--- a/Part2_PlatformBenchmarks/BenchmarkHelpers.h
+++ b/Part2_PlatformBenchmarks/BenchmarkHelpers.h
@@ -25,46 +25,12 @@ template<typename A>
 struct is_same<A, A> : true_type {};
 }  // namespace benchmark_detail
 
-struct MinDurationResult {
-  uint32_t ops;
-  unsigned long elapsedUs;
-};
-
-template<typename Func>
-MinDurationResult runForAtLeastUs(unsigned long minUs, Func fn) {
-  MinDurationResult result = {};
-  unsigned long start = micros();
-  unsigned long elapsed = 0;
-  do {
-    result.ops += fn();
-#if defined(ESP32) || defined(ESP8266) || defined(ARDUINO_ARCH_RP2040)
-    yield();
-#endif
-    elapsed = micros() - start;
-  } while (elapsed < minUs);
-  result.elapsedUs = elapsed;
-  return result;
-}
-
 struct TimedLoopResult {
   unsigned long elapsedMicros;
   uint32_t iterations;
   uint32_t totalOps;
   float opsPerMs;
 };
-
-// Helper function for void return type
-template<typename Func>
-void runFuncVoid(Func& func, bool& shouldBreak) {
-  func();
-  shouldBreak = false;
-}
-
-// Helper function for non-void return type
-template<typename Func>
-void runFuncNonVoid(Func& func, bool& shouldBreak) {
-  shouldBreak = !func();
-}
 
 template<typename Func>
 bool runFuncAndCheck(Func& func, benchmark_detail::true_type) {

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ See [BOARD_STATUS.md](BOARD_STATUS.md) for which boards have been tested and whi
 
 - **Volatile accumulators** prevent the compiler from optimizing away operations
 - **Checksummed results** verify actual execution
-- **Minimum-duration loops** ensure stable timing (`runForAtLeastUs`, `runTimedLoop`)
+- **Minimum-duration loops** ensure stable timing (`runTimedLoop`)
 - **Register-level access** measured alongside API calls to quantify abstraction overhead
 - **Jitter analysis** (5-trial runs) for timing precision benchmarks
 - **yield() calls** on RTOS-based boards (ESP32, ESP8266, RP2040) to prevent watchdog resets


### PR DESCRIPTION
Neither sketch calls runForAtLeastUs or MinDurationResult, and runFuncVoid/runFuncNonVoid are dead code never referenced anywhere. Both files now contain only what is actually used: runTimedLoop, TimedLoopResult, runFuncAndCheck, and the benchmark_detail types that support the void/non-void dispatch.

Both copies are trimmed identically since both parts use the same subset of helpers. The separate copies are still required because Arduino IDE resolves includes relative to the sketch directory.

https://claude.ai/code/session_01XD7vxWykxjmAaNQPRoFNUw