### PR TITLE
Document CSV output mode and import script in v1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [1.0.1] - 2026-02-20
 
+### Added
+- **CSV output mode** — compile-time `#define CSV_OUTPUT 1` flag (default 0) in
+  `BenchmarkHelpers.h` switches both sketches from human-readable Serial output to
+  `label,value` CSV rows, one per metric; all 252 result prints across Part 1 and
+  Part 2 are wrapped in `#if !CSV_OUTPUT` guards with matching `CSV_ROW` /
+  `CSV_BLANK` calls so every board always emits the same fixed row count
+- **`tools/import_results.py`** — Python script that reads the CSV Serial output,
+  locates the board column in a versioned `.xlsx` spreadsheet (or creates a new
+  one), matches each label to its spreadsheet row by name, and writes the numeric
+  values automatically — no manual row lookup needed. Usage:
+  ```
+  # 1. Set #define CSV_OUTPUT 1 in BenchmarkHelpers.h, upload, copy Serial output
+  python tools/import_results.py output.csv Part1_CoreBenchmarks_Results_v1.0.1.xlsx
+  ```
+
 ### Fixed
 - BLE scan now runs on ArduinoBLE-capable boards (Nano 33 BLE, RP2040 Connect,
   SAMD Nano 33 IoT, Portenta H7/C33, Giga R1, Wio Terminal) instead of printing

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,18 +53,27 @@ If you notice incorrect or missing data in the results spreadsheets:
 1. Decide if it belongs in **Part 1** (universal — runs on all boards) or **Part 2** (platform-specific)
 2. Write a function following the naming pattern: `benchmarkFeatureName()`
 3. Use `runTimedLoop()` for throughput tests or `micros()` for latency tests
-4. Print results with `Serial.print()` / `Serial.println()` matching the existing output format:
+4. Print results with `SERIAL_OUT.print()` / `SERIAL_OUT.println()` matching the existing output format, wrapped in `#if !CSV_OUTPUT` / `#endif`:
+   ```cpp
+   #if !CSV_OUTPUT
+   SERIAL_OUT.print(F_STR("Test Name: "));
+   SERIAL_OUT.print(result);
+   SERIAL_OUT.println(F_STR(" ops/ms"));
+   #endif
+   CSV_ROW("Test Name (ops/ms)", result);
    ```
-   [Category] Test Name: <value> <unit>
-   ```
-5. Call your function from `setup()` in the appropriate sketch (after the existing benchmarks)
-6. Guard any hardware-specific code with preprocessor conditionals:
+5. For every board-conditional result path that does **not** run the benchmark, emit a `CSV_BLANK` so all boards always produce the same number of CSV rows:
    ```cpp
    #if defined(ESP32)
-     // ESP32-only benchmark code
+     // ... benchmark ...
+     CSV_ROW("Test Name (ops/ms)", result);
+   #else
+     CSV_BLANK("Test Name (ops/ms)");
    #endif
    ```
-7. Test on at least one physical board before submitting
+6. Call your function from `setup()` in the appropriate sketch (after the existing benchmarks)
+7. Guard any hardware-specific code in `#if defined(...)` / `#endif` preprocessor conditionals
+8. Test on at least one physical board before submitting
 
 ### Adding Support for a New Board
 
@@ -79,7 +88,7 @@ If you notice incorrect or missing data in the results spreadsheets:
 
 ### Pull Request Process
 
-1. Fork the repository and create a branch from `v1.0.0`
+1. Fork the repository and create a branch from `v1.0.1`
 2. Make your changes
 3. Test on physical hardware — simulator results are not accepted
 4. Include Serial Monitor output in the PR description showing your changes work
@@ -107,11 +116,11 @@ You do **not** need to bump the version for:
 
 ### How to Bump
 
-1. **Create a new branch** from `v1.0.0` for your changes — do **not** work directly on the `v1.0.0` branch or any existing results branch
-2. **Update `BENCHMARK_VERSION`** in both `Part1_CoreBenchmarks/BenchmarkHelpers.h` and `Part2_PlatformBenchmarks/BenchmarkHelpers.h` (e.g. `"1.0.0"` → `"1.1.0"`)
+1. **Create a new branch** from `v1.0.1` for your changes — do **not** work directly on the `v1.0.1` branch or any existing results branch
+2. **Update `BENCHMARK_VERSION`** in both `Part1_CoreBenchmarks/BenchmarkHelpers.h` and `Part2_PlatformBenchmarks/BenchmarkHelpers.h` (e.g. `"1.0.1"` → `"1.1.0"`)
 3. **Copy the previous spreadsheets as-is**: Copy `Part1_CoreBenchmarks_Results_v<OLD_VERSION>.xlsx` to `Part1_CoreBenchmarks_Results_v<NEW_VERSION>.xlsx` and similarly for Part 2 — keep all existing board columns and result data intact. Do **not** modify or delete the previous version's spreadsheets. In each new spreadsheet, add a **"Version"** row immediately below the board name row; enter the benchmark version that produced each board's data (previous boards keep their old version number until they are re-tested under the new version)
 4. **Copy `BOARD_STATUS.md`** as-is — keep the board list and all existing results. When boards are re-tested under the new version, their rows will be overwritten with the new results
-5. **Do not overwrite the `v1.0.0` branch** — previous benchmark versions and their results must be preserved
+5. **Do not overwrite the `v1.0.1` branch** — previous benchmark versions and their results must be preserved
 
 ### Version Numbering
 
@@ -138,6 +147,8 @@ Benchmark results are tracked in versioned spreadsheet pairs — one per benchma
    - Arduino core/platform version (from Boards Manager)
    - Arduino IDE version
    - Any non-default settings (clock speed, flash mode, etc.)
+
+**Tip — CSV mode for faster entry:** Set `#define CSV_OUTPUT 1` in `BenchmarkHelpers.h` before uploading. Copy the `label,value` Serial output to a `.csv` file, then run `python tools/import_results.py output.csv Part1_CoreBenchmarks_Results_v<VERSION>.xlsx` to populate the spreadsheet automatically. Remember to set `CSV_OUTPUT` back to `0` when done.
 
 ### Formatting Results
 

--- a/README.md
+++ b/README.md
@@ -21,8 +21,10 @@ Boards are detected automatically at compile time using preprocessor macros — 
 ├── Part2_PlatformBenchmarks/
 │   ├── Part2_PlatformBenchmarks.ino # Platform-specific tests
 │   └── BenchmarkHelpers.h          # Shared timing utilities + benchmark version
-├── Part1_CoreBenchmarks_Results_v1.0.0.xlsx  # Core results (benchmark v1.0.0)
-├── Part2_PlatformBenchmarks_Results_v1.0.0.xlsx # Platform results (benchmark v1.0.0)
+├── tools/
+│   └── import_results.py           # CSV-to-spreadsheet import script
+├── Part1_CoreBenchmarks_Results_v1.0.1.xlsx  # Core results (benchmark v1.0.1)
+├── Part2_PlatformBenchmarks_Results_v1.0.1.xlsx # Platform results (benchmark v1.0.1)
 ├── reports/                          # Raw Serial Monitor output per board
 ├── BOARD_STATUS.md                   # Board testing tracker (status + benchmark version)
 ├── CHANGELOG.md                      # Version history and notable changes
@@ -55,6 +57,8 @@ Advanced and board-specific tests:
 
 ## How to Use
 
+### Human-readable output (default)
+
 1. Open **Arduino IDE**
 2. Select your board and port
 3. Open `Part1_CoreBenchmarks/Part1_CoreBenchmarks.ino`
@@ -66,6 +70,16 @@ Advanced and board-specific tests:
 9. Record Part 1 results in `Part1_CoreBenchmarks_Results_v<BENCHMARK_VERSION>.xlsx` and Part 2 results in `Part2_PlatformBenchmarks_Results_v<BENCHMARK_VERSION>.xlsx` (the benchmark version is printed in the Serial Monitor output)
 
 Results are printed as operations per millisecond (ops/ms), timing in microseconds, and other metrics depending on the test.
+
+### CSV output + automatic spreadsheet import
+
+For faster data entry, set `#define CSV_OUTPUT 1` in `BenchmarkHelpers.h` before uploading. The sketch will emit `label,value` rows instead of the human-readable output. Copy the Serial Monitor output to a `.csv` file, then run:
+
+```sh
+python tools/import_results.py output.csv Part1_CoreBenchmarks_Results_v1.0.1.xlsx
+```
+
+The script finds the board column by name (or creates a new one), matches each label to its spreadsheet row, and writes all numeric values automatically. Repeat for Part 2 with the Part 2 `.csv` and spreadsheet. Remember to set `CSV_OUTPUT` back to `0` when you want the normal output.
 
 See [BOARD_STATUS.md](BOARD_STATUS.md) for which boards have been tested and which still need results.
 


### PR DESCRIPTION
- CHANGELOG.md: Add ### Added section to [1.0.1] covering CSV_OUTPUT flag, CSV_ROW/CSV_BLANK macros, and tools/import_results.py
- README.md: Add tools/ to repository structure, split How to Use into human-readable and CSV sections, document import_results.py workflow
- CONTRIBUTING.md: Require CSV_ROW/CSV_BLANK for new benchmarks, update PR branch reference from v1.0.0 to v1.0.1, add CSV mode tip to data-submission workflow, update version-bump instructions

https://claude.ai/code/session_018XdAjEthmpjgRw3opRd2uP