### PR TITLE
docs: clarify COMPILE_LIST compile environment assumptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ See [BOARD_STATUS.md](BOARD_STATUS.md) for which boards have been tested and whi
 - **Board Manager URLs** — third-party boards (ESP32, RP2040, Teensy, STM32, etc.) require their respective Board Manager URLs to be added in Arduino IDE preferences before the board can be installed
 - **External library** — the Multiduino board requires the [Adafruit RTClib](https://github.com/adafruit/RTClib) library (`RTClib.h`); all other boards use only platform-bundled libraries
 
+> **Compile list note:** All boards listed as test-compiled in [COMPILE_LIST.md](COMPILE_LIST.md) were compiled using Arduino IDE **2.3.7** with the latest available board core versions at the time. No guarantees are made that they will compile on any other IDE or core version.
+
 ## Measurement Methodology
 
 - **Volatile accumulators** prevent the compiler from optimizing away operations


### PR DESCRIPTION
## Summary
- add a README note stating that boards marked test-compiled in `COMPILE_LIST.md` were compiled with Arduino IDE 2.3.7
- clarify that the compile checks used the latest board core versions available at the time
- add a disclaimer that compilation is not guaranteed on other IDE/core versions

## Files changed
- `README.md`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69981a67fe048331a4af2e09b19093c9)